### PR TITLE
Higher-precision coordinate conversions

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -18,15 +18,18 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}
     name: Testing
-    #    needs: [linter]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9]
+    defaults:
+     run:
+       # Adding -l {0} helps ensure conda can be found properly in windows.
+       shell: bash -l {0}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
         with:
           fetch-depth: 1
 

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Install
         run: |
+          echo $(which pip)
           pip install .[test]
 
       - name: Run Tests

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -29,17 +29,35 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 1
-      - name: Get Python
-        uses: actions/setup-python@v2
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
+          auto-update-conda: true
+          miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
+          environment-file: ci/test-env.yml
+          activate-environment: tests
+
+      - name: Conda Info
+        run: |
+          conda info -a
+          conda list
+          PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
+          if [[ $PYVER != $PYTHON ]]; then
+            exit 1;
+          fi
+
       - name: Install
         run: |
           pip install .[test]
+
       - name: Run Tests
         run: |
           python -m pytest --cov=vis_cpu --cov-config=.coveragerc --cov-report xml:./coverage.xml --durations=25
-      - uses: codecov/codecov-action@master
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@master
         if: matrix.os == 'ubuntu-latest' && success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -26,21 +26,35 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     defaults:
      run:
-       # Adding -l {0} helps ensure conda can be found properly in windows.
+       # Adding -l {0} ensures conda can be found properly in each step
        shell: bash -l {0}
     steps:
       - uses: actions/checkout@main
         with:
           fetch-depth: 1
 
+      - name: Cache conda
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache if ci/test-env.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}-${{ hashFiles('ci/test-env.yml', 'setup.cfg') }}
+
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           auto-update-conda: true
-          miniconda-version: "latest"
+          # miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
           environment-file: ci/test-env.yml
           activate-environment: tests
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: strict
+          use-only-tar-bz2: true
 
       - name: Conda Info
         run: |

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -46,12 +46,11 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          auto-update-conda: true
-          # miniconda-version: "latest"
+          # auto-update-conda: true
+          miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
           environment-file: ci/test-env.yml
           activate-environment: tests
-          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: strict
           use-only-tar-bz2: true

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -3,5 +3,15 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - mpi4py  # Required here so that we get
-  - pip
+  - mpi4py>=3.0  # Required here so that we get
+  - astropy>=4<5
+  - numpy>=1.15
+  - scipy>=1.5
+  - pip>=20.1
+  - pytest==6.2.4
+  - pytest-cov==2.11.1
+  - matplotlib>=3.2.2
+  - ipython==7.15
+  - pip:
+    - pyuvsim[sim]>=1.2
+    - pyradiosky>=0.1.1

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -3,16 +3,16 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - mpi4py>=3.0  # Required here so that we get
+  - mpi4py>=3.0,<4  # Required here so that we get
   - astropy>=4,<5
   - numpy>=1.15,<1.17
   - scipy>=1.5,<1.7
   - pip>=20.1
-  - pytest=6.2.4
-  - pytest-cov=2.11.1
+  - pytest>=6.2.4
+  - pytest-cov>=2.11.1
   - matplotlib>=3.2.2,<4
-  - ipython=7.15
+  - ipython>=7.15
   - h5py>=3.2,<4
   - pip:
-    - pyuvsim[sim]>=1.2
-    - pyradiosky>=0.1.1
+    - pyuvsim[sim]>=1.2,<1.4
+    - pyradiosky>=0.1.1,<0.3

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -12,6 +12,7 @@ dependencies:
   - pytest-cov=2.11.1
   - matplotlib>=3.2.2,<4
   - ipython=7.15
+  - h5py>=3.2,<4
   - pip:
     - pyuvsim[sim]>=1.2
     - pyradiosky>=0.1.1

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -5,13 +5,13 @@ channels:
 dependencies:
   - mpi4py>=3.0,<4  # Required here so that we get
   - astropy>=4,<5
-  - numpy>=1.15,<1.17
-  - scipy>=1.5,<1.7
-  - pip>=20.1
+  - numpy>=1.20,<2.0
+  - scipy>=1.6,<2.0
+  - pip>=21.1,<22
   - pytest>=6.2.4
   - pytest-cov>=2.11.1
-  - matplotlib>=3.2.2,<4
-  - ipython>=7.15
+  - matplotlib>=3.3.4,<4
+  - ipython>=7.22,<8
   - h5py>=3.2,<4
   - pip:
     - pyuvsim[sim]>=1.2,<1.4

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -1,0 +1,11 @@
+name: tests
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pyuvsim[sim]
+  - pytest
+  - pytest-cov
+  - pyradiosky
+  - matplotlib
+  - ipython

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -4,14 +4,14 @@ channels:
   - defaults
 dependencies:
   - mpi4py>=3.0  # Required here so that we get
-  - astropy>=4<5
-  - numpy>=1.15
-  - scipy>=1.5
+  - astropy>=4,<5
+  - numpy>=1.15,<1.17
+  - scipy>=1.5,<1.7
   - pip>=20.1
-  - pytest==6.2.4
-  - pytest-cov==2.11.1
-  - matplotlib>=3.2.2
-  - ipython==7.15
+  - pytest=6.2.4
+  - pytest-cov=2.11.1
+  - matplotlib>=3.2.2,<4
+  - ipython=7.15
   - pip:
     - pyuvsim[sim]>=1.2
     - pyradiosky>=0.1.1

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -3,9 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pyuvsim[sim]
-  - pytest
-  - pytest-cov
-  - pyradiosky
-  - matplotlib
-  - ipython
+  - mpi4py  # Required here so that we get

--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - mpi4py  # Required here so that we get
+  - pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ test =
     pytest-cov
     pyuvsim
     pyradiosky
-    hera_sim
+    hera_sim @ git+git://github.com/HERA-Team/hera_sim
     matplotlib
     ipython
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ exclude =
 test =
     pytest
     pytest-cov
-    pyuvsim
+    pyuvsim[sim]
     pyradiosky
     matplotlib
     ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ exclude =
 test =
     pytest
     pytest-cov
-    mpi4py @ git+git://github.com/mpi4py/mpi4py
     pyuvsim[sim]
     pyradiosky
     matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ test =
     pytest
     pytest-cov
     pyuvsim
+    pyradiosky
+    hera_sim
     matplotlib
     ipython
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ test =
     pytest-cov
     pyuvsim
     pyradiosky
-    hera_sim @ git+git://github.com/HERA-Team/hera_sim
     matplotlib
     ipython
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ exclude =
 test =
     pytest
     pytest-cov
+    mpi4py @ git+git://github.com/mpi4py/mpi4py
     pyuvsim[sim]
     pyradiosky
     matplotlib

--- a/src/vis_cpu/conversions.py
+++ b/src/vis_cpu/conversions.py
@@ -1,27 +1,185 @@
 """Functions for converting co-ordinates."""
+import astropy.units as u
 import numpy as np
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates.builtin_frames import AltAz
+from astropy.time import Time
 
 
-def lm_to_az_za(el, m):
-    """
-    Convert l and m (on intervals -1, +1) to azimuth and zenith angle.
+def enu_to_az_za(enu_e, enu_n):
+    """Convert angle cosines in ENU coordinates into azimuth and zenith angle.
 
-    In an East-North-Up (ENU) coordinate system, m = vec{p}.hat{e}
-    and el = vec{p}.hat{n} for a pointing vector vec{p}.
+    For a pointing vector in ENU coordinates vec{p}, the input arguments are
+    ``enu_e = vec{p}.hat{e}`` and ``enu_n = vec{p}.hat{n}`, where ``hat{e}`` is
+    a unit vector in ENU coordinates etc.
 
     Parameters
     ----------
-    el, m : array_like
-        Normalized angular coordinates on the interval (-1, +1).
+    enu_e, enu_n : array_like
+        Normalized angle cosine coordinates on the interval (-1, +1).
 
     Returns
     -------
     az, za : array_like
         Corresponding azimuth and zenith angles (in radians).
     """
-    lsqr = el ** 2.0 + m ** 2.0
-    n = np.where(lsqr < 1.0, np.sqrt(1.0 - lsqr), 0.0)
+    lsqr = enu_n ** 2.0 + enu_e ** 2.0
+    zeta = np.where(lsqr < 1.0, np.sqrt(1.0 - lsqr), 0.0)
 
-    az = -np.arctan2(m, el)
-    za = np.pi / 2.0 - np.arcsin(n)
+    az = -np.arctan2(enu_e, enu_n)
+    za = 0.5 * np.pi - np.arcsin(zeta)
     return az, za
+
+
+def eci_to_enu_matrix(ha, lat):
+    """3x3 transformation matrix to rotate ECI to ENU coordinates.
+
+    Transformation matrix to project Earth-Centered Inertial (ECI) coordinates
+    to local observer-centric East-North-Up (ENU) coordinates at a given time
+    and location.
+
+    Note: This is a stripped-down version of the ``eq2top_m`` function.
+
+    Parameters
+    ----------
+    ha : float
+        Hour angle, in radians, where HA = LST - RA. Normally, this is passed
+        in as ``ha = -lst``.
+
+    lat : float
+        Latitude of the observer, in radians.
+
+    Returns
+    -------
+    m : array_like
+        Array of 3x3 matrices containing the rotation matrices for each time.
+    """
+    # Reference: https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
+    return np.array(
+        [
+            [np.sin(ha), np.cos(ha), 0.0 * ha],
+            [-np.sin(lat) * np.cos(ha), np.sin(lat) * np.sin(ha), np.cos(lat)],
+            [np.cos(lat) * np.cos(ha), -np.cos(lat) * np.sin(ha), np.sin(lat)],
+        ]
+    )
+
+
+def enu_to_eci_matrix(ha, lat):
+    """3x3 transformation matrix to rotate ENU to ECI coordinates.
+
+    3x3 transformation matrix to project local observer-centric East-North-Up
+    (ENU) coordinates at a given time and location to Earth-Centered Inertial
+    (ECI) coordinates.
+
+    Parameters
+    ----------
+    ha : float
+        Hour angle, in radians, where HA = LST - RA. Normally, this is passed
+        in as ``ha = -lst``.
+
+    lat : float
+        Latitude of the observer, in radians.
+
+    Returns
+    -------
+    m : array_like
+        Array of 3x3 matrices containing the rotation matrices for each time.
+    """
+    # Reference: https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
+    return np.array(
+        [
+            [np.sin(ha), -np.cos(ha) * np.sin(lat), np.cos(ha) * np.cos(lat)],
+            [np.cos(ha), np.sin(ha) * np.sin(lat), -np.sin(ha) * np.cos(lat)],
+            [0.0 * ha, np.cos(lat), np.sin(lat)],
+        ]
+    )
+
+
+def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs"):
+    """Convert RA and Dec coordinates into the ECI system used by vis_cpu.
+
+    Convert RA and Dec coordinates into the ECI (Earth-Centered Inertial)
+    system used by vis_cpu.
+
+    To ensure that all corrections are properly taken into account, this
+    function uses Astropy to find the Alt/Az positions of the coordinates at a
+    specified reference time and location. These are then transformed back to
+    ENU (East-North-Up) coordinates, and then to Cartesian ECI coordinates,
+    using the inverses of the same transforms that are used to do the forward
+    transforms when running ``vis_cpu``. The ECI coordinates are then finally
+    converted back into adjusted RA and Dec coordinates in the ECI system.
+
+    While the time-dependent corrections are determined for the reference time,
+    the adjusted coordinates are expected to yield a good approximation to the
+    true Azimuth and Zenith angle of the sources at other times (but the same
+    location) when passed into the ``vis_cpu`` function via the ``crd_eq``
+    array and then converted using the standard conversions within ``vis_cpu``.
+
+    The following example code shows how to set up the Astropy ``Time`` and
+    ``EarthLocation`` objects that are required by this function::
+
+        # HERA location
+        location = EarthLocation.from_geodetic(lat=-30.7215,
+                                               lon=21.4283,
+                                               height=1073.)
+        # Observation time
+        t = Time('2018-08-31T04:02:30.11', format='isot', scale='utc')
+
+
+    Parameters
+    ----------
+    ra, dec : array_like
+        Input RA and Dec positions. The units and reference frame of these
+        positions can be set using the ``unit`` and ``frame`` kwargs.
+
+    obstime : astropy.Time object
+        ``Time`` object specifying the time of the reference observation.
+
+    location : astropy.EarthLocation
+        ``EarthLocation`` object specifying the location of the reference
+        observation.
+
+    unit : str, optional
+        Which units the input RA and Dec values are in, using names intelligible
+        to ``astropy.SkyCoord``. Default: 'rad'.
+
+    frame : str, optional
+        Which frame that input RA and Dec positions are specified in. Any
+        system recognized by ``astropy.SkyCoord`` can be used. Default: 'icrs'.
+
+    Returns
+    -------
+    eci_ra, eci_dec : array_like
+        Arrays of RA and Dec coordinates with respect to the ECI system used
+        by vis_cpu.
+    """
+    assert isinstance(obstime, Time), "obstime must be an astropy.Time object"
+    assert isinstance(
+        location, EarthLocation
+    ), "location must be an astropy.EarthLocation object"
+
+    # Local sidereal time at this obstime and location
+    lst = obstime.sidereal_time("mean", longitude=location.lon).rad
+
+    # Create Astropy SkyCoord object
+    skycoords = SkyCoord(ra, dec, unit=unit, frame=frame)
+
+    # Rotation matrix from Cartesian ENU to Cartesian ECI
+    m = enu_to_eci_matrix(-lst, location.lat.rad)  # Evaluated at HA (= LST - RA) = -LST
+
+    # Get AltAz and ENU coords of sources at reference time and location. Ref:
+    # https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
+    alt_az = skycoords.transform_to(AltAz(obstime=obstime, location=location))
+    el, az = alt_az.alt.rad, alt_az.az.rad
+    astropy_enu = np.array(
+        [np.cos(el) * np.sin(az), np.cos(el) * np.cos(az), np.sin(el)]
+    )
+
+    # Convert to ECI coordinates using ENU->ECI transform
+    astropy_eci = np.dot(m, astropy_enu)
+
+    # Infer RA and Dec coords from astropy ECI
+    px, py, pz = astropy_eci
+    pdec = np.arcsin(pz)
+    pra = np.arctan2(py, px)
+    return pra, pdec

--- a/src/vis_cpu/conversions.py
+++ b/src/vis_cpu/conversions.py
@@ -7,28 +7,50 @@ from astropy.coordinates.builtin_frames import AltAz
 from astropy.time import Time
 
 
-def enu_to_az_za(enu_e, enu_n):
+def enu_to_az_za(enu_e, enu_n, orientation="astropy"):
     """Convert angle cosines in ENU coordinates into azimuth and zenith angle.
 
-    For a pointing vector in ENU coordinates vec{p}, the input arguments are
-    ``enu_e = vec{p}.hat{e}`` and ``enu_n = vec{p}.hat{n}`, where ``hat{e}`` is
-    a unit vector in ENU coordinates etc.
+    For a pointing vector in East-North-Up (ENU) coordinates vec{p}, the input 
+    arguments are ``enu_e = vec{p}.hat{e}`` and ``enu_n = vec{p}.hat{n}`, where 
+    ``hat{e}`` is a unit vector in ENU coordinates etc.
+    
+    For a drift-scan telescope pointing at the zenith, the ``hat{e}`` direction 
+    is aligned with the ``U`` direction (in the UVW plane), which means that we 
+    can identify the direction cosines ``l = enu_e`` and ``m = enu_n``.
+    
+    Azimuth is oriented East of North, i.e. Az(N) = 0 deg, Az(E) = +90 deg in  
+    the astropy convention, and North of East, i.e. Az(N) = +90 deg, and 
+    Az(E) = 0 deg in the UVBeam convention.
 
     Parameters
     ----------
     enu_e, enu_n : array_like
         Normalized angle cosine coordinates on the interval (-1, +1).
-
+    
+    orientation : str, optional
+        Orientation convention used for the azimuth angle. The default is 
+        ``'astropy'``, which uses an East of North convention (Az(N) = 0 deg, 
+        Az(E) = +90 deg). Alternatively, the ``'uvbeam'`` convention uses 
+        North of East (Az(N) = +90 deg, Az(E) = 0 deg).
+    
     Returns
     -------
     az, za : array_like
         Corresponding azimuth and zenith angles (in radians).
     """
+    assert orientation in ['astropy', 'uvbeam'], \
+        "orientation must be either 'astropy' or 'uvbeam'"
+    
     lsqr = enu_n ** 2.0 + enu_e ** 2.0
     zeta = np.where(lsqr < 1.0, np.sqrt(1.0 - lsqr), 0.0)
 
-    az = -np.arctan2(enu_e, enu_n)
+    az = np.arctan2(enu_e, enu_n)
     za = 0.5 * np.pi - np.arcsin(zeta)
+    
+    # Flip and rotate azimuth coordinate if uvbeam convention is used
+    if orientation == 'uvbeam':
+        az = 0.5*np.pi - az
+    
     return az, za
 
 
@@ -38,14 +60,18 @@ def eci_to_enu_matrix(ha, lat):
     Transformation matrix to project Earth-Centered Inertial (ECI) coordinates
     to local observer-centric East-North-Up (ENU) coordinates at a given time
     and location.
+    
+    The ECI coordinates are aligned with the celestial pole, i.e. for (x,y,z)
+    (RA=0  deg, Dec=0  deg) = (1, 0, 0)
+    (RA=90 deg, Dec=0  deg) = (0, 1, 0)
+    (RA=0  deg, Dec=90 deg) = (0, 0, 1)
 
     Note: This is a stripped-down version of the ``eq2top_m`` function.
 
     Parameters
     ----------
     ha : float
-        Hour angle, in radians, where HA = LST - RA. Normally, this is passed
-        in as ``ha = -lst``.
+        Hour angle, in radians, where HA = LST - RA.
 
     lat : float
         Latitude of the observer, in radians.
@@ -53,14 +79,14 @@ def eci_to_enu_matrix(ha, lat):
     Returns
     -------
     m : array_like
-        Array of 3x3 matrices containing the rotation matrices for each time.
+        3x3 array containing the rotation matrix for a given time.
     """
     # Reference: https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
     return np.array(
         [
-            [np.sin(ha), np.cos(ha), 0.0 * ha],
-            [-np.sin(lat) * np.cos(ha), np.sin(lat) * np.sin(ha), np.cos(lat)],
-            [np.cos(lat) * np.cos(ha), -np.cos(lat) * np.sin(ha), np.sin(lat)],
+            [-np.sin(ha), np.cos(ha), 0.0 * ha],
+            [-np.sin(lat) * np.cos(ha), -np.sin(lat) * np.sin(ha), np.cos(lat)],
+            [np.cos(lat) * np.cos(ha), np.cos(lat) * np.sin(ha), np.sin(lat)],
         ]
     )
 
@@ -71,12 +97,16 @@ def enu_to_eci_matrix(ha, lat):
     3x3 transformation matrix to project local observer-centric East-North-Up
     (ENU) coordinates at a given time and location to Earth-Centered Inertial
     (ECI) coordinates.
+    
+    The ECI coordinates are aligned with the celestial pole, i.e. for (x,y,z)
+    (RA=0  deg, Dec=0  deg) = (1, 0, 0)
+    (RA=90 deg, Dec=0  deg) = (0, 1, 0)
+    (RA=0  deg, Dec=90 deg) = (0, 0, 1)
 
     Parameters
     ----------
     ha : float
-        Hour angle, in radians, where HA = LST - RA. Normally, this is passed
-        in as ``ha = -lst``.
+        Hour angle, in radians, where HA = LST - RA.
 
     lat : float
         Latitude of the observer, in radians.
@@ -84,13 +114,13 @@ def enu_to_eci_matrix(ha, lat):
     Returns
     -------
     m : array_like
-        Array of 3x3 matrices containing the rotation matrices for each time.
+        3x3 array containing the rotation matrix for a given time.
     """
     # Reference: https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
     return np.array(
         [
-            [np.sin(ha), -np.cos(ha) * np.sin(lat), np.cos(ha) * np.cos(lat)],
-            [np.cos(ha), np.sin(ha) * np.sin(lat), -np.sin(ha) * np.cos(lat)],
+            [-np.sin(ha), -np.cos(ha) * np.sin(lat), np.cos(ha) * np.cos(lat)],
+            [np.cos(ha), -np.sin(ha) * np.sin(lat), np.sin(ha) * np.cos(lat)],
             [0.0 * ha, np.cos(lat), np.sin(lat)],
         ]
     )
@@ -98,7 +128,19 @@ def enu_to_eci_matrix(ha, lat):
 
 def point_source_crd_eq(ra, dec):
     """Coordinate transform of source locations from equatorial to Cartesian.
-
+    
+    This converts RA and Dec angles to a Cartesian x,y,z unit vector in an 
+    Earth-Centered Inertial (ECI) coordinate system aligned with the celestial 
+    pole, i.e. for (x,y,z)
+    (RA=0  deg, Dec=0  deg) = (1, 0, 0)
+    (RA=90 deg, Dec=0  deg) = (0, 1, 0)
+    (RA=0  deg, Dec=90 deg) = (0, 0, 1)
+    
+    The RA and Dec are assumed to be in a particular reference frame that may 
+    not match-up with standard frames like ICRS/J2000. To convert coordinates 
+    from a standard system into the relevant frame, see 
+    :func:`~equatorial_to_eci_coords`.
+    
     Parameters
     ----------
     ra, dec : array_like
@@ -117,7 +159,8 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
     """Convert RA and Dec coordinates into the ECI system used by vis_cpu.
 
     Convert RA and Dec coordinates into the ECI (Earth-Centered Inertial)
-    system used by vis_cpu.
+    system used by vis_cpu. This ECI system is aligned with the celestial pole, 
+    not the Earth's axis.
 
     To ensure that all corrections are properly taken into account, this
     function uses Astropy to find the Alt/Az positions of the coordinates at a
@@ -192,6 +235,7 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
     astropy_enu = np.array(
         [np.cos(el) * np.sin(az), np.cos(el) * np.cos(az), np.sin(el)]
     )
+    # In astropy, Az oriented East of North, i.e. Az(N) = 0 deg, Az(E) = +90 deg
 
     # Convert to ECI coordinates using ENU->ECI transform
     astropy_eci = np.dot(m, astropy_enu)
@@ -204,7 +248,12 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
 
 
 def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
-    """Convert a UVbeam to a uniform (l,m) grid.
+    """Evaluate a UVBeam object on a uniform direction cosine (l,m) grid.
+    
+    Here, (l, m) are the direction cosines, associated with the East and North 
+    ENU coordinates (and also the U and V directions for a zenith-pointing 
+    drift-scan telescope). For a vector in East-North-Up (ENU) coordinates 
+    vec{p}, we therefore have ``l = vec{p}.hat{e}`` etc.
 
     Parameters
     ----------
@@ -229,14 +278,10 @@ def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
     L, m = np.meshgrid(L, L)
     L = L.flatten()
     m = m.flatten()
-
-    # Apply horizon cut
-    lsqr = L ** 2.0 + m ** 2.0
-    n = np.where(lsqr < 1.0, np.sqrt(1.0 - lsqr), 0.0)
-
-    # Calculate azimuth and zenith angle
-    az = -np.arctan2(m, L)
-    za = np.pi / 2.0 - np.arcsin(n)
+    
+    # Get azimuth and zenith angles (note the different azimuth convention 
+    # used by UVBeam)
+    az, za = enu_to_az_za(enu_e=L, enu_n=m, orientation="uvbeam")
 
     # Interpolate beam onto cube
     efield_beam = uvbeam.interp(az, za, freqs, **kwargs)[0]
@@ -261,3 +306,4 @@ def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
         if np.max(bm) > 0.0:
             bm /= np.max(bm)
         return bm.reshape((len(freqs), n_pix_lm, n_pix_lm))
+        

--- a/src/vis_cpu/conversions.py
+++ b/src/vis_cpu/conversions.py
@@ -186,7 +186,7 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
                                                lon=21.4283,
                                                height=1073.)
         # Observation time
-        t = Time('2018-08-31T04:02:30.11', format='isot', scale='utc')
+        obstime = Time('2018-08-31T04:02:30.11', format='isot', scale='utc')
 
 
     Parameters

--- a/src/vis_cpu/conversions.py
+++ b/src/vis_cpu/conversions.py
@@ -216,10 +216,10 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
         Arrays of RA and Dec coordinates with respect to the ECI system used
         by vis_cpu.
     """
-    assert isinstance(obstime, Time), "obstime must be an astropy.Time object"
-    assert isinstance(
-        location, EarthLocation
-    ), "location must be an astropy.EarthLocation object"
+    if not isinstance(obstime, Time):
+        raise TypeError("obstime must be an astropy.Time object")
+    if not isinstance(location, EarthLocation):
+        raise TypeError("location must be an astropy.EarthLocation object")
 
     # Local sidereal time at this obstime and location
     lst = obstime.sidereal_time("mean", longitude=location.lon).rad

--- a/src/vis_cpu/conversions.py
+++ b/src/vis_cpu/conversions.py
@@ -222,13 +222,13 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
         raise TypeError("location must be an astropy.EarthLocation object")
 
     # Local sidereal time at this obstime and location
-    lst = obstime.sidereal_time("mean", longitude=location.lon).rad
+    lst = obstime.sidereal_time("apparent", longitude=location.lon).rad
 
     # Create Astropy SkyCoord object
     skycoords = SkyCoord(ra, dec, unit=unit, frame=frame)
 
     # Rotation matrix from Cartesian ENU to Cartesian ECI
-    m = enu_to_eci_matrix(-lst, location.lat.rad)  # Evaluated at HA (= LST - RA) = -LST
+    m = enu_to_eci_matrix(lst, location.lat.rad)  # Evaluated at HA (= LST - RA) = LST
 
     # Get AltAz and ENU coords of sources at reference time and location. Ref:
     # https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates

--- a/src/vis_cpu/conversions.py
+++ b/src/vis_cpu/conversions.py
@@ -10,47 +10,49 @@ from astropy.time import Time
 def enu_to_az_za(enu_e, enu_n, orientation="astropy"):
     """Convert angle cosines in ENU coordinates into azimuth and zenith angle.
 
-    For a pointing vector in East-North-Up (ENU) coordinates vec{p}, the input 
-    arguments are ``enu_e = vec{p}.hat{e}`` and ``enu_n = vec{p}.hat{n}`, where 
+    For a pointing vector in East-North-Up (ENU) coordinates vec{p}, the input
+    arguments are ``enu_e = vec{p}.hat{e}`` and ``enu_n = vec{p}.hat{n}`, where
     ``hat{e}`` is a unit vector in ENU coordinates etc.
-    
-    For a drift-scan telescope pointing at the zenith, the ``hat{e}`` direction 
-    is aligned with the ``U`` direction (in the UVW plane), which means that we 
+
+    For a drift-scan telescope pointing at the zenith, the ``hat{e}`` direction
+    is aligned with the ``U`` direction (in the UVW plane), which means that we
     can identify the direction cosines ``l = enu_e`` and ``m = enu_n``.
-    
-    Azimuth is oriented East of North, i.e. Az(N) = 0 deg, Az(E) = +90 deg in  
-    the astropy convention, and North of East, i.e. Az(N) = +90 deg, and 
+
+    Azimuth is oriented East of North, i.e. Az(N) = 0 deg, Az(E) = +90 deg in
+    the astropy convention, and North of East, i.e. Az(N) = +90 deg, and
     Az(E) = 0 deg in the UVBeam convention.
 
     Parameters
     ----------
     enu_e, enu_n : array_like
         Normalized angle cosine coordinates on the interval (-1, +1).
-    
+
     orientation : str, optional
-        Orientation convention used for the azimuth angle. The default is 
-        ``'astropy'``, which uses an East of North convention (Az(N) = 0 deg, 
-        Az(E) = +90 deg). Alternatively, the ``'uvbeam'`` convention uses 
+        Orientation convention used for the azimuth angle. The default is
+        ``'astropy'``, which uses an East of North convention (Az(N) = 0 deg,
+        Az(E) = +90 deg). Alternatively, the ``'uvbeam'`` convention uses
         North of East (Az(N) = +90 deg, Az(E) = 0 deg).
-    
+
     Returns
     -------
     az, za : array_like
         Corresponding azimuth and zenith angles (in radians).
     """
-    assert orientation in ['astropy', 'uvbeam'], \
-        "orientation must be either 'astropy' or 'uvbeam'"
-    
+    assert orientation in [
+        "astropy",
+        "uvbeam",
+    ], "orientation must be either 'astropy' or 'uvbeam'"
+
     lsqr = enu_n ** 2.0 + enu_e ** 2.0
     zeta = np.where(lsqr < 1.0, np.sqrt(1.0 - lsqr), 0.0)
 
     az = np.arctan2(enu_e, enu_n)
     za = 0.5 * np.pi - np.arcsin(zeta)
-    
+
     # Flip and rotate azimuth coordinate if uvbeam convention is used
-    if orientation == 'uvbeam':
-        az = 0.5*np.pi - az
-    
+    if orientation == "uvbeam":
+        az = 0.5 * np.pi - az
+
     return az, za
 
 
@@ -60,7 +62,7 @@ def eci_to_enu_matrix(ha, lat):
     Transformation matrix to project Earth-Centered Inertial (ECI) coordinates
     to local observer-centric East-North-Up (ENU) coordinates at a given time
     and location.
-    
+
     The ECI coordinates are aligned with the celestial pole, i.e. for (x,y,z)
     (RA=0  deg, Dec=0  deg) = (1, 0, 0)
     (RA=90 deg, Dec=0  deg) = (0, 1, 0)
@@ -97,7 +99,7 @@ def enu_to_eci_matrix(ha, lat):
     3x3 transformation matrix to project local observer-centric East-North-Up
     (ENU) coordinates at a given time and location to Earth-Centered Inertial
     (ECI) coordinates.
-    
+
     The ECI coordinates are aligned with the celestial pole, i.e. for (x,y,z)
     (RA=0  deg, Dec=0  deg) = (1, 0, 0)
     (RA=90 deg, Dec=0  deg) = (0, 1, 0)
@@ -128,19 +130,19 @@ def enu_to_eci_matrix(ha, lat):
 
 def point_source_crd_eq(ra, dec):
     """Coordinate transform of source locations from equatorial to Cartesian.
-    
-    This converts RA and Dec angles to a Cartesian x,y,z unit vector in an 
-    Earth-Centered Inertial (ECI) coordinate system aligned with the celestial 
+
+    This converts RA and Dec angles to a Cartesian x,y,z unit vector in an
+    Earth-Centered Inertial (ECI) coordinate system aligned with the celestial
     pole, i.e. for (x,y,z)
     (RA=0  deg, Dec=0  deg) = (1, 0, 0)
     (RA=90 deg, Dec=0  deg) = (0, 1, 0)
     (RA=0  deg, Dec=90 deg) = (0, 0, 1)
-    
-    The RA and Dec are assumed to be in a particular reference frame that may 
-    not match-up with standard frames like ICRS/J2000. To convert coordinates 
-    from a standard system into the relevant frame, see 
+
+    The RA and Dec are assumed to be in a particular reference frame that may
+    not match-up with standard frames like ICRS/J2000. To convert coordinates
+    from a standard system into the relevant frame, see
     :func:`~equatorial_to_eci_coords`.
-    
+
     Parameters
     ----------
     ra, dec : array_like
@@ -159,7 +161,7 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
     """Convert RA and Dec coordinates into the ECI system used by vis_cpu.
 
     Convert RA and Dec coordinates into the ECI (Earth-Centered Inertial)
-    system used by vis_cpu. This ECI system is aligned with the celestial pole, 
+    system used by vis_cpu. This ECI system is aligned with the celestial pole,
     not the Earth's axis.
 
     To ensure that all corrections are properly taken into account, this
@@ -235,7 +237,7 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
     astropy_enu = np.array(
         [np.cos(el) * np.sin(az), np.cos(el) * np.cos(az), np.sin(el)]
     )
-    # In astropy, Az oriented East of North, i.e. Az(N) = 0 deg, Az(E) = +90 deg
+    # astropy has Az oriented East of North, i.e. Az(N) = 0 deg, Az(E) = +90 deg
 
     # Convert to ECI coordinates using ENU->ECI transform
     astropy_eci = np.dot(m, astropy_enu)
@@ -249,10 +251,10 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
 
 def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
     """Evaluate a UVBeam object on a uniform direction cosine (l,m) grid.
-    
-    Here, (l, m) are the direction cosines, associated with the East and North 
-    ENU coordinates (and also the U and V directions for a zenith-pointing 
-    drift-scan telescope). For a vector in East-North-Up (ENU) coordinates 
+
+    Here, (l, m) are the direction cosines, associated with the East and North
+    ENU coordinates (and also the U and V directions for a zenith-pointing
+    drift-scan telescope). For a vector in East-North-Up (ENU) coordinates
     vec{p}, we therefore have ``l = vec{p}.hat{e}`` etc.
 
     Parameters
@@ -278,8 +280,8 @@ def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
     L, m = np.meshgrid(L, L)
     L = L.flatten()
     m = m.flatten()
-    
-    # Get azimuth and zenith angles (note the different azimuth convention 
+
+    # Get azimuth and zenith angles (note the different azimuth convention
     # used by UVBeam)
     az, za = enu_to_az_za(enu_e=L, enu_n=m, orientation="uvbeam")
 
@@ -306,4 +308,3 @@ def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
         if np.max(bm) > 0.0:
             bm /= np.max(bm)
         return bm.reshape((len(freqs), n_pix_lm, n_pix_lm))
-        

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -170,11 +170,12 @@ def vis_cpu(
                 # Extract requested polarizations
                 for p1 in range(nax):
                     for p2 in range(nfeed):
-                        # FIXME: Need to check whether the beam pixel grid has been reshaped in l,m or m,l order
+                        # FIXME: Need to check whether the beam pixel grid has
+                        # been reshaped in l,m or m,l order
                         A_s[p1, p2, i] = splines[p1][p2][i](ty, tx, grid=False)
         else:
             # Primary beam pattern using direct interpolation of UVBeam object
-            az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation='uvbeam')
+            az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation="uvbeam")
             for i in range(nant):
                 interp_beam = beam_list[i].interp(az, za, np.atleast_1d(freq))[0]
 

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -170,10 +170,11 @@ def vis_cpu(
                 # Extract requested polarizations
                 for p1 in range(nax):
                     for p2 in range(nfeed):
+                        # FIXME: Need to check whether the beam pixel grid has been reshaped in l,m or m,l order
                         A_s[p1, p2, i] = splines[p1][p2][i](ty, tx, grid=False)
         else:
             # Primary beam pattern using direct interpolation of UVBeam object
-            az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty)
+            az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation='uvbeam')
             for i in range(nant):
                 interp_beam = beam_list[i].interp(az, za, np.atleast_1d(freq))[0]
 

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -90,7 +90,11 @@ def vis_cpu(
         (cos(RA) cos(Dec), sin(RA) cos(Dec), sin(Dec)).
         Shape=(3, NSRCS).
     I_sky : array_like
-        Intensity distribution of sources/pixels on the sky.
+        Intensity distribution of sources/pixels on the sky, assuming intensity
+        (Stokes I) only. The Stokes I intensity will be split equally between
+        the two linear polarization channels, resulting in a factor of 0.5 from
+        the value inputted here. This is done even if only one polarization
+        channel is simulated.
         Shape=(NSRCS,).
     bm_cube : array_like, optional
         Pixelized beam maps for each antenna. Shape=(NANT, BM_PIX, BM_PIX).
@@ -168,11 +172,12 @@ def vis_cpu(
         assert len(beam_list) == nant, "beam_list must have length nant"
 
     # Intensity distribution (sqrt) and antenna positions. Does not support
-    # negative sky.
-    Isqrt = np.sqrt(I_sky).astype(real_dtype)
+    # negative sky. Factor of 0.5 accounts for splitting Stokes I between
+    # polarization channels
+    Isqrt = 0.5 * np.sqrt(I_sky).astype(real_dtype)
     antpos = antpos.astype(real_dtype)
 
-    ang_freq = 2 * np.pi * freq
+    ang_freq = 2.0 * np.pi * freq
 
     # Zero arrays: beam pattern, visibilities, delays, complex voltages
     A_s = np.zeros((nax, nfeed, nant, nsrcs), dtype=real_dtype)

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -135,7 +135,7 @@ def vis_cpu(
                 # TODO: Try using a log-space beam for accuracy!
         else:
             # Primary beam pattern using direct interpolation of UVBeam object
-            az, za = conversions.lm_to_az_za(el=ty, m=tx)
+            az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty)
             for i in range(nant):
                 interp_beam = beam_list[i].interp(az, za, np.atleast_1d(freq))[0]
                 A_s[i] = interp_beam[0, 0, 1]  # FIXME: assumes xx pol for now

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -174,7 +174,7 @@ def vis_cpu(
     # Intensity distribution (sqrt) and antenna positions. Does not support
     # negative sky. Factor of 0.5 accounts for splitting Stokes I between
     # polarization channels
-    Isqrt = 0.5 * np.sqrt(I_sky).astype(real_dtype)
+    Isqrt = np.sqrt(0.5 * I_sky).astype(real_dtype)
     antpos = antpos.astype(real_dtype)
 
     ang_freq = 2.0 * np.pi * freq

--- a/src/vis_cpu/wrapper.py
+++ b/src/vis_cpu/wrapper.py
@@ -94,7 +94,7 @@ def simulate_vis(
     crd_eq = conversions.point_source_crd_eq(ra, dec)
 
     # Get coordinate transforms as a function of LST
-    eq2tops = np.array([conversions.eci_to_enu_matrix(-lst, latitude) for lst in lsts])
+    eq2tops = np.array([conversions.eci_to_enu_matrix(lst, latitude) for lst in lsts])
 
     # Create beam pixel models (if requested)
     if pixel_beams:

--- a/src/vis_cpu/wrapper.py
+++ b/src/vis_cpu/wrapper.py
@@ -83,8 +83,12 @@ def simulate_vis(
 
     # Get polarization information from beams
     if polarized:
-        naxes = beams[0].Naxes_vec
-        nfeeds = beams[0].Nfeeds
+        try:
+            naxes = beams[0].Naxes_vec
+            nfeeds = beams[0].Nfeeds
+        except AttributeError:
+            # If Naxes_vec and Nfeeds properties aren't set, assume no pol.
+            naxes = nfeeds = 1
 
     # Antenna x,y,z positions
     antpos = np.array([ants[k] for k in ants.keys()])

--- a/src/vis_cpu/wrapper.py
+++ b/src/vis_cpu/wrapper.py
@@ -94,7 +94,7 @@ def simulate_vis(
     crd_eq = conversions.point_source_crd_eq(ra, dec)
 
     # Get coordinate transforms as a function of LST
-    eq2tops = conversions.eci_to_enu_matrix(-lsts, latitude)  # HERA latitude
+    eq2tops = np.array([conversions.eci_to_enu_matrix(-lst, latitude) for lst in lsts])
 
     # Create beam pixel models (if requested)
     if pixel_beams:

--- a/tests/test_beams.py
+++ b/tests/test_beams.py
@@ -1,0 +1,167 @@
+"""Test that pixel and analytic beams are properly aligned."""
+import numpy as np
+from pyuvsim import AnalyticBeam
+
+from vis_cpu import conversions, simulate_vis, vis_cpu
+
+np.random.seed(0)
+NTIMES = 3
+NFREQ = 2
+NPTSRC = 400
+ants = {0: (0, 0, 0), 1: (1, 1, 0)}
+
+
+class EllipticalBeam(object):
+    """Add ellipticity/shearing to an existing UVBeam/AnalyticBeam object."""
+
+    def __init__(self, base_beam, xstretch=1.0, ystretch=1.0, rotation=0.0):
+        """
+        Take an existing UVBeam/AnalyticBeam and apply stretching/rotation.
+
+        Parameters
+        ----------
+        base_beam : UVBeam or AnalyticBeam object
+            Existing beam object that will be sheared/stretched/rotated.
+
+        xstretch, ystretch : float, optional
+            Stretching factors to apply to the beam in the x and y directions,
+            which introduces beam ellipticity, as well as an overall
+            stretching/shrinking. Default: 1.0 (no ellipticity or stretching).
+
+        rotation : float, optional
+            Rotation of the beam in the x-y plane, in degrees. Only has an
+            effect if xstretch != ystretch. Default: 0.0.
+        """
+        self.base_beam = base_beam
+        self.xstretch = xstretch
+        self.ystretch = ystretch
+        self.rotation = rotation
+
+    def interp(self, az_array, za_array, freq_array):
+        """Evaluate the beam after applying shearing, stretching, or rotation.
+
+        Parameters
+        ----------
+        az_array : array_like
+            Azimuth values in radians (same length as za_array). The azimuth
+            here has the UVBeam convention: North of East(East=0, North=pi/2)
+
+        za_array : array_like
+            Zenith angle values in radians (same length as az_array).
+
+        freq_array : array_like
+            Frequency values to evaluate at.
+
+        Returns
+        -------
+        interp_data : array_like
+            Array of beam values, shape (Naxes_vec, Nspws, Nfeeds or Npols,
+            Nfreqs or freq_array.size if freq_array is passed,
+            Npixels/(Naxis1, Naxis2) or az_array.size if az/za_arrays are passed)
+
+        interp_basis_vector : array_like
+            Array of interpolated basis vectors (or self.basis_vector_array
+            if az/za_arrays are not passed), shape: (Naxes_vec, Ncomponents_vec,
+            Npixels/(Naxis1, Naxis2) or az_array.size if az/za_arrays are passed)
+        """
+        # Apply shearing, stretching, or rotation
+        if self.xstretch != 1.0 or self.ystretch != 1.0:
+            # Convert sheared Cartesian coords to circular polar coords
+            # mX stretches in x direction, mY in y direction, a is angle
+            # Notation: phi = az, theta = za. Subscript 's' are transformed coords
+            a = self.rotation * np.pi / 180.0
+            X = za_array * np.cos(az_array)
+            Y = za_array * np.sin(az_array)
+            Xs = (X * np.cos(a) - Y * np.sin(a)) / self.xstretch
+            Ys = (X * np.sin(a) + Y * np.cos(a)) / self.ystretch
+
+            # Updated polar coordinates
+            theta_s = np.sqrt(Xs ** 2.0 + Ys ** 2.0)
+            phi_s = np.arccos(Xs / theta_s)
+            phi_s[Ys < 0.0] *= -1.0
+
+            # Fix coordinates below the horizon of the unstretched beam
+            theta_s[np.where(theta_s < 0.0)] = 0.5 * np.pi
+            theta_s[np.where(theta_s >= np.pi / 2.0)] = 0.5 * np.pi
+
+            # Update za_array and az_array
+            az_array, za_array = phi_s, theta_s
+
+        # Call interp() method on BaseBeam
+        interp_data, interp_basis_vector = self.base_beam.interp(
+            az_array=az_array, za_array=za_array, freq_array=freq_array
+        )
+
+        return interp_data, interp_basis_vector
+
+
+def test_beam_interpolation():
+    """Test that interpolated beams and UVBeam agree on coordinates."""
+    # Point source equatorial coords (radians)
+    ra = np.linspace(0.0, 2.0 * np.pi, NPTSRC)
+    dec = np.linspace(-0.5 * np.pi, 0.5 * np.pi, NPTSRC)
+
+    # Antenna x,y,z positions and frequency array
+    antpos = np.array([ants[k] for k in ants.keys()])
+    freq = np.linspace(100.0e6, 120.0e6, NFREQ)  # Hz
+
+    # SED for each point source
+    fluxes = np.ones(NPTSRC)
+    I_sky = fluxes[:, np.newaxis] * (freq[np.newaxis, :] / 100.0e6) ** -2.7
+
+    # Get Gaussian beam and transform into an elliptical version
+    base_beam = AnalyticBeam("gaussian", diameter=14.0)
+    beam_analytic = EllipticalBeam(base_beam, xstretch=2.2, ystretch=1.0, rotation=40.0)
+    beam_list = [beam_analytic, beam_analytic]
+
+    # Construct pixel beam from analytic beam
+    beam_pix = conversions.uvbeam_to_lm(
+        beam_analytic, freq, n_pix_lm=1000, polarized=False
+    )
+    beam_cube = np.array([beam_pix, beam_pix])
+
+    # Point source coordinate transform, from equatorial to Cartesian
+    crd_eq = conversions.point_source_crd_eq(ra, dec)
+
+    # Get coordinate transforms as a function of LST
+    hera_lat = -30.7215 * np.pi / 180.0
+    lsts = np.linspace(0.0, 2.0 * np.pi, NTIMES)
+    eq2tops = np.array(
+        [conversions.eci_to_enu_matrix(lst, lat=hera_lat) for lst in lsts]
+    )
+
+    # Run vis_cpu with pixel beams and analytic beams (uses precision=2)
+    # This test is useful for checking a particular line in vis_cpu() that
+    # evaluates the pixel beam splines, i.e. `splines[p1][p2][i](ty, tx, ...)`
+    # This test should fail if the order of the arguments (ty, tx) is wrong
+    for i in range(freq.size):
+        # Pixel beams
+        vis_pix = vis_cpu(
+            antpos,
+            freq[i],
+            eq2tops,
+            crd_eq,
+            I_sky[:, i],
+            bm_cube=beam_cube[:, i, :, :],
+            precision=2,
+            polarized=False,
+        )
+
+        # Analytic beams
+        vis_analytic = vis_cpu(
+            antpos,
+            freq[i],
+            eq2tops,
+            crd_eq,
+            I_sky[:, i],
+            beam_list=beam_list,
+            precision=2,
+            polarized=False,
+        )
+
+        assert np.all(~np.isnan(vis_pix))  # check that there are no NaN values
+        assert np.all(~np.isnan(vis_analytic))
+
+        # Check that results are close (they should be for 1000^2 pixel-beams
+        # if the elliptical beams are both oriented the same way)
+        assert np.allclose(vis_pix, vis_analytic, rtol=1e-5, atol=1e-5)

--- a/tests/test_compare_pyuvsim.py
+++ b/tests/test_compare_pyuvsim.py
@@ -11,7 +11,7 @@ from vis_cpu import conversions, simulate_vis, vis_cpu
 
 nfreq = 3
 ntime = 20
-nants = 3
+nants = 10  # 3
 nsource = 500
 
 
@@ -140,10 +140,8 @@ def test_compare_pyuvsim():
     diff_im = 0.0
     for i in range(nants):
         for j in range(i, nants):
-            d_uvsim = uvd_uvsim.get_data((i, j, "XX")).T
-
-            # FIXME: There is a factor of 2 in amplitude unaccounted for
-            d_viscpu = 0.5 * vis_vc[:, :, i, j]
+            d_uvsim = uvd_uvsim.get_data((i, j, "XX")).T  # pyuvsim visibility
+            d_viscpu = vis_vc[:, :, i, j]  # vis_cpu visibility
 
             # Keep track of maximum difference
             delta = d_uvsim - d_viscpu

--- a/tests/test_compare_pyuvsim.py
+++ b/tests/test_compare_pyuvsim.py
@@ -11,7 +11,7 @@ from vis_cpu import conversions, simulate_vis, vis_cpu
 
 nfreq = 3
 ntime = 20
-nants = 10  # 3
+nants = 4
 nsource = 500
 
 

--- a/tests/test_compare_pyuvsim.py
+++ b/tests/test_compare_pyuvsim.py
@@ -1,0 +1,140 @@
+"""Compare vis_cpu with pyuvsim visibilities."""
+import numpy as np
+from astropy.coordinates import EarthLocation, Latitude, Longitude
+from astropy.time import Time
+from astropy.units import Quantity
+from hera_sim import io
+from pyradiosky import SkyModel
+from pyuvsim import AnalyticBeam, simsetup, uvsim
+from pyuvsim.telescope import BeamList
+
+from vis_cpu import conversions, simulate_vis, vis_cpu
+
+nfreq = 3
+ntime = 5
+nants = 3
+nsource = 500
+
+
+def test_compare_pyuvsim():
+    """Compare vis_cpu and pyuvsim simulated visibilities."""
+    hera_lat = -30.7215
+    hera_lon = 21.4283
+    hera_alt = 1073.0
+    obstime = Time("2018-08-31T04:02:30.11", format="isot", scale="utc")
+
+    # HERA location
+    location = EarthLocation.from_geodetic(lat=hera_lat, lon=hera_lon, height=hera_alt)
+
+    np.random.seed(1)
+
+    # Random antenna locations
+    x = np.random.random(nants) * 400.0  # Up to 400 metres
+    y = np.random.random(nants) * 400.0
+    z = np.random.random(nants) * 0.0
+    ants = {}
+    for i in range(nants):
+        ants[i] = (x[i], y[i], z[i])
+
+    # Observing parameters in a UVData object.
+    uvdata = io.empty_uvdata(
+        nfreq=nfreq,  # Need >=2 freqs for healvis to work
+        start_freq=100e6,
+        channel_width=97.3e3,
+        start_time=obstime.jd,
+        integration_time=1820.0,  # Just over 30 mins between time samples
+        ntimes=ntime,
+        ants=ants,
+        polarization_array=np.array(["XX", "YY", "XY", "YX"]),
+        Npols=4,
+    )
+    lsts = np.unique(uvdata.lst_array)
+
+    # One fixed source plus random other sources
+    sources = [
+        [125.7, -30.72, 2, 0],  # Fix a single source near zenith
+    ]
+    if nsource > 1:  # Add random other sources
+        ra = np.random.uniform(low=0.0, high=360.0, size=nsource - 1)
+        dec = -30.72 + np.random.random(nsource - 1) * 10.0
+        flux = np.random.random(nsource - 1) * 4
+        for i in range(nsource - 1):
+            sources.append([ra[i], dec[i], flux[i], 0])
+    sources = np.array(sources)
+
+    # Source locations and frequencies
+    ra_dec = np.deg2rad(sources[:, :2])
+    freqs = np.unique(uvdata.freq_array)
+
+    # Correct source locations so that vis_cpu uses the right frame
+    ra_new, dec_new = conversions.equatorial_to_eci_coords(
+        ra_dec[:, 0], ra_dec[:, 1], obstime, location, unit="rad", frame="icrs"
+    )
+
+    # Calculate source fluxes for vis_cpu
+    flux = ((freqs[:, np.newaxis] / freqs[0]) ** sources[:, 3].T * sources[:, 2].T).T
+    # beam_ids = list(ants.keys())
+
+    # Beam model
+    beams = [AnalyticBeam("gaussian", diameter=14.0) for i in range(len(ants.keys()))]
+    # beams = [AnalyticBeam('uniform') for i in range(len(ants.keys()))]
+    beam_dict = {}
+    for i in range(len(beams)):
+        beam_dict[str(i)] = i
+
+    # Stokes for the first frequency only. Stokes for other frequencies
+    # are calculated later.
+    stokes = np.zeros((4, 1, ra_dec.shape[0]))
+    stokes[0, 0] = sources[:, 2]
+    reference_frequency = np.full(len(ra_dec), freqs[0])
+
+    # Set up sky model
+    sky_model = SkyModel(
+        name=[str(i) for i in range(len(ra_dec))],
+        ra=Longitude(ra_dec[:, 0], "rad"),
+        dec=Latitude(ra_dec[:, 1], "rad"),
+        spectral_type="spectral_index",
+        spectral_index=sources[:, 3],
+        stokes=stokes,
+        reference_frequency=Quantity(reference_frequency, "Hz"),
+    )
+
+    # Calculate stokes at all the frequencies.
+    sky_model.at_frequencies(Quantity(freqs, "Hz"), inplace=True)
+
+    # ---------------------------------------------------------------------------
+    # (1) Run vis_cpu
+    # ---------------------------------------------------------------------------
+    vis_vc = simulate_vis(
+        ants=ants,
+        fluxes=flux,
+        ra=ra_new,
+        dec=dec_new,
+        freqs=freqs,
+        lsts=lsts,
+        beams=beams,
+        pixel_beams=False,
+        polarized=False,
+        precision=2,
+        latitude=hera_lat * np.pi / 180.0,
+    )
+
+    # ---------------------------------------------------------------------------
+    # (2) Run pyuvsim
+    # ---------------------------------------------------------------------------
+    uvd_uvsim = uvsim.run_uvdata_uvsim(
+        uvdata,
+        BeamList(beams),
+        beam_dict=beam_dict,
+        catalog=simsetup.SkyModelData(sky_model),
+    )
+
+    # ---------------------------------------------------------------------------
+    # Compare
+    # ---------------------------------------------------------------------------
+    # Loop over baselines and compare
+    for i in range(nants):
+        for j in range(i, nants):
+            d = uvd_uvsim.get_data((i, j, "XX")).T
+            # FIXME: There is a factor of 2 in amplitude unaccounted for
+            assert np.allclose(0.5 * vis_vc[:, :, i, j], d, rtol=2e-4, atol=2e-4)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,0 +1,150 @@
+"""Tests of coordinate conversions."""
+import pytest
+
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates.builtin_frames import AltAz
+from astropy.time import Time
+
+from vis_cpu import conversions
+
+np.random.seed(0)
+NTIMES = 4
+NFREQ = 5
+NPTSRC = 20
+
+
+def test_equatorial_to_cosines():
+    """Test conversions from RA, Dec to direction cosines.
+    
+    This tests the conversion of RA and Dec angles to a Cartesian x,y,z unit 
+    vector in an Earth-Centered Inertial (ECI) coordinate system aligned with 
+    the celestial pole, i.e. for (x,y,z)
+    (RA=0  deg, Dec=0  deg) = (1, 0, 0)
+    (RA=90 deg, Dec=0  deg) = (0, 1, 0)
+    (RA=0  deg, Dec=90 deg) = (0, 0, 1)
+    """
+    # HERA latitude
+    hera_lat = -30.7215 * np.pi / 180.0
+    
+    # Point source equatorial coords in assumed ECI system (deg)
+    ra = np.array([0., 45., 90., 135., 180., 270., 360.]) * np.pi / 180.
+    
+    #---------------------------------------------------------------------------
+    # (1) Source at Dec = +90 degrees (North Celestial Pole)
+    #---------------------------------------------------------------------------
+    # Get ECI direction cosines for RA, Dec1 (source at Dec=90)
+    dec1 = 0.5 * np.pi * np.ones(ra.size) # Dec = 90 deg
+    crd_eq1 = conversions.point_source_crd_eq(ra, dec1)
+    
+    # The x,y directions should be zero, and the z direction should be 1
+    assert np.allclose(crd_eq1[0], 0.*np.ones(ra.size))
+    assert np.allclose(crd_eq1[1], 0.*np.ones(ra.size))
+    assert np.allclose(crd_eq1[2], 1.*np.ones(ra.size))
+    
+    #---------------------------------------------------------------------------
+    # (2) Source at Dec = -90 degrees (South Celestial Pole)
+    #---------------------------------------------------------------------------
+    # Get ECI direction cosines for RA, -Dec1 (source at Dec=-90)
+    crd_eq1 = conversions.point_source_crd_eq(ra, -dec1)
+    
+    # The x,y directions should be zero, and the z direction should be 1
+    assert np.allclose(crd_eq1[0], 0.*np.ones(ra.size))
+    assert np.allclose(crd_eq1[1], 0.*np.ones(ra.size))
+    assert np.allclose(crd_eq1[2], -1.*np.ones(ra.size))
+    
+    #---------------------------------------------------------------------------
+    # (3) Source at Dec = 0 degrees (Celestial Equator)
+    #---------------------------------------------------------------------------
+    # Get ECI direction cosines for RA, 0 (source at Dec=0)
+    crd_eq1 = conversions.point_source_crd_eq(ra, 0.*dec1)
+    
+    # The z direction should be 0; in plane perpendicular to Celestial poles
+    assert np.isclose(crd_eq1[0,0], 1.) # RA=0, should be in x direction
+    assert np.isclose(crd_eq1[1,0], 0.)
+    assert np.isclose(crd_eq1[0,2], 0.) # RA=90, should be in y direction
+    assert np.isclose(crd_eq1[1,2], 1.)
+    assert np.allclose(crd_eq1[2], 0.*np.ones(ra.size)) # Perp. to poles
+
+
+def test_equatorial_to_enu():
+    """Test conversions from RA, Dec to ENU and Az/ZA coordinates."""
+    # HERA latitude
+    hera_lat = -30.7215 * np.pi / 180.0
+    lsts = np.linspace(0.0, 2.0 * np.pi, NTIMES)
+    
+    # Point source equatorial coords in assumed ECI system (deg)
+    # RA is at zenith crossing, i.e. hour angle HA = LST - RA = 0 => RA = LST
+    # So, one of these sources should be found exactly at the zenith at each LST
+    ra = lsts
+    dec = hera_lat * np.ones(ra.size) # Dec = HERA latitude
+    
+    # Get Cartesian coords for these sources in our ECI system
+    crd_eq = conversions.point_source_crd_eq(ra, dec)
+    
+    # Loop over LSTs
+    for i, lst in enumerate(lsts):
+        # Rotation matrices from ECI <-> ENU
+        mat_eci_to_enu = conversions.eci_to_enu_matrix(lst, lat=hera_lat)
+        mat_enu_to_eci = conversions.enu_to_eci_matrix(lst, lat=hera_lat)
+        
+        # Convert to local direction cosines l,m,n
+        tx, ty, tz = crd_top = np.dot(mat_eci_to_enu, crd_eq)
+        
+        # Ensure that the source with RA = lst is exactly overhead
+        assert np.isclose(tx[i], 0.)
+        assert np.isclose(ty[i], 0.)
+        assert np.isclose(tz[i], 1.)
+        
+        # Ensure that inverse-transformed coords match for all sources
+        crd_eq2 = np.dot(mat_enu_to_eci, crd_top)
+        assert np.allclose(crd_eq, crd_eq2)
+        
+        # Check that zenith angle is zero when source with RA = lst is overhead
+        az, za = conversions.enu_to_az_za(tx, ty, orientation='astropy')
+        az_uvb, za_uvb = conversions.enu_to_az_za(tx, ty, orientation='uvbeam')
+        assert np.isclose(za[i], 0.)
+        assert np.isclose(za_uvb[i], 0.)
+        
+        # Check that E, N, U are aligned with Az/ZA as expected
+        vec_e = np.array([1., 0., 0.])
+        vec_n = np.array([0., 1., 0.])
+        vec_u = np.array([0., 0., 1.])
+        
+        # Pointing East (astropy)
+        _az, _za = conversions.enu_to_az_za(vec_e[0], vec_e[1], orientation='astropy')
+        assert np.isclose(_az, 0.5*np.pi)
+        assert np.isclose(_za, 0.5*np.pi)
+        
+        # Pointing North (astropy)
+        _az, _za = conversions.enu_to_az_za(vec_n[0], vec_n[1], orientation='astropy')
+        assert np.isclose(_az, 0.)
+        assert np.isclose(_za, 0.5*np.pi)
+        
+        # Pointing Up (astropy)
+        _az, _za = conversions.enu_to_az_za(vec_u[0], vec_u[1], orientation='astropy')
+        assert np.isclose(_az, 0.)
+        assert np.isclose(_za, 0.)
+        
+        # Pointing East (UVBeam)
+        _az, _za = conversions.enu_to_az_za(vec_e[0], vec_e[1], orientation='uvbeam')
+        assert np.isclose(_az, 0.)
+        assert np.isclose(_za, 0.5*np.pi)
+        
+        # Pointing North (UVBeam)
+        _az, _za = conversions.enu_to_az_za(vec_n[0], vec_n[1], orientation='uvbeam')
+        assert np.isclose(_az, 0.5*np.pi)
+        assert np.isclose(_za, 0.5*np.pi)
+        
+        # Pointing Up (UVBeam)
+        _az, _za = conversions.enu_to_az_za(vec_u[0], vec_u[1], orientation='uvbeam')
+        assert np.isclose(_za, 0.)
+        
+        # Do inverse transform and check
+        eq_e = np.dot(mat_enu_to_eci, vec_e)
+        _tx, _ty, _tz = np.dot(mat_eci_to_enu, eq_e)
+        assert np.isclose(_tx, 1.)
+        assert np.isclose(_ty, 0.)
+        assert np.isclose(_tz, 0.)
+        

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,8 +1,8 @@
 """Tests of coordinate conversions."""
 import pytest
 
-import numpy as np
 import astropy.units as u
+import numpy as np
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.coordinates.builtin_frames import AltAz
 from astropy.time import Time
@@ -17,55 +17,52 @@ NPTSRC = 20
 
 def test_equatorial_to_cosines():
     """Test conversions from RA, Dec to direction cosines.
-    
-    This tests the conversion of RA and Dec angles to a Cartesian x,y,z unit 
-    vector in an Earth-Centered Inertial (ECI) coordinate system aligned with 
+
+    This tests the conversion of RA and Dec angles to a Cartesian x,y,z unit
+    vector in an Earth-Centered Inertial (ECI) coordinate system aligned with
     the celestial pole, i.e. for (x,y,z)
     (RA=0  deg, Dec=0  deg) = (1, 0, 0)
     (RA=90 deg, Dec=0  deg) = (0, 1, 0)
     (RA=0  deg, Dec=90 deg) = (0, 0, 1)
     """
-    # HERA latitude
-    hera_lat = -30.7215 * np.pi / 180.0
-    
     # Point source equatorial coords in assumed ECI system (deg)
-    ra = np.array([0., 45., 90., 135., 180., 270., 360.]) * np.pi / 180.
-    
-    #---------------------------------------------------------------------------
+    ra = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 270.0, 360.0]) * np.pi / 180.0
+
+    # ---------------------------------------------------------------------------
     # (1) Source at Dec = +90 degrees (North Celestial Pole)
-    #---------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
     # Get ECI direction cosines for RA, Dec1 (source at Dec=90)
-    dec1 = 0.5 * np.pi * np.ones(ra.size) # Dec = 90 deg
+    dec1 = 0.5 * np.pi * np.ones(ra.size)  # Dec = 90 deg
     crd_eq1 = conversions.point_source_crd_eq(ra, dec1)
-    
+
     # The x,y directions should be zero, and the z direction should be 1
-    assert np.allclose(crd_eq1[0], 0.*np.ones(ra.size))
-    assert np.allclose(crd_eq1[1], 0.*np.ones(ra.size))
-    assert np.allclose(crd_eq1[2], 1.*np.ones(ra.size))
-    
-    #---------------------------------------------------------------------------
+    assert np.allclose(crd_eq1[0], 0.0 * np.ones(ra.size))
+    assert np.allclose(crd_eq1[1], 0.0 * np.ones(ra.size))
+    assert np.allclose(crd_eq1[2], 1.0 * np.ones(ra.size))
+
+    # ---------------------------------------------------------------------------
     # (2) Source at Dec = -90 degrees (South Celestial Pole)
-    #---------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
     # Get ECI direction cosines for RA, -Dec1 (source at Dec=-90)
     crd_eq1 = conversions.point_source_crd_eq(ra, -dec1)
-    
+
     # The x,y directions should be zero, and the z direction should be 1
-    assert np.allclose(crd_eq1[0], 0.*np.ones(ra.size))
-    assert np.allclose(crd_eq1[1], 0.*np.ones(ra.size))
-    assert np.allclose(crd_eq1[2], -1.*np.ones(ra.size))
-    
-    #---------------------------------------------------------------------------
+    assert np.allclose(crd_eq1[0], 0.0 * np.ones(ra.size))
+    assert np.allclose(crd_eq1[1], 0.0 * np.ones(ra.size))
+    assert np.allclose(crd_eq1[2], -1.0 * np.ones(ra.size))
+
+    # ---------------------------------------------------------------------------
     # (3) Source at Dec = 0 degrees (Celestial Equator)
-    #---------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
     # Get ECI direction cosines for RA, 0 (source at Dec=0)
-    crd_eq1 = conversions.point_source_crd_eq(ra, 0.*dec1)
-    
+    crd_eq1 = conversions.point_source_crd_eq(ra, 0.0 * dec1)
+
     # The z direction should be 0; in plane perpendicular to Celestial poles
-    assert np.isclose(crd_eq1[0,0], 1.) # RA=0, should be in x direction
-    assert np.isclose(crd_eq1[1,0], 0.)
-    assert np.isclose(crd_eq1[0,2], 0.) # RA=90, should be in y direction
-    assert np.isclose(crd_eq1[1,2], 1.)
-    assert np.allclose(crd_eq1[2], 0.*np.ones(ra.size)) # Perp. to poles
+    assert np.isclose(crd_eq1[0, 0], 1.0)  # RA=0, should be in x direction
+    assert np.isclose(crd_eq1[1, 0], 0.0)
+    assert np.isclose(crd_eq1[0, 2], 0.0)  # RA=90, should be in y direction
+    assert np.isclose(crd_eq1[1, 2], 1.0)
+    assert np.allclose(crd_eq1[2], 0.0 * np.ones(ra.size))  # Perp. to poles
 
 
 def test_equatorial_to_enu():
@@ -73,78 +70,78 @@ def test_equatorial_to_enu():
     # HERA latitude
     hera_lat = -30.7215 * np.pi / 180.0
     lsts = np.linspace(0.0, 2.0 * np.pi, NTIMES)
-    
+
     # Point source equatorial coords in assumed ECI system (deg)
     # RA is at zenith crossing, i.e. hour angle HA = LST - RA = 0 => RA = LST
     # So, one of these sources should be found exactly at the zenith at each LST
     ra = lsts
-    dec = hera_lat * np.ones(ra.size) # Dec = HERA latitude
-    
+    dec = hera_lat * np.ones(ra.size)  # Dec = HERA latitude
+
     # Get Cartesian coords for these sources in our ECI system
     crd_eq = conversions.point_source_crd_eq(ra, dec)
-    
+
     # Loop over LSTs
     for i, lst in enumerate(lsts):
+
         # Rotation matrices from ECI <-> ENU
         mat_eci_to_enu = conversions.eci_to_enu_matrix(lst, lat=hera_lat)
         mat_enu_to_eci = conversions.enu_to_eci_matrix(lst, lat=hera_lat)
-        
+
         # Convert to local direction cosines l,m,n
         tx, ty, tz = crd_top = np.dot(mat_eci_to_enu, crd_eq)
-        
+
         # Ensure that the source with RA = lst is exactly overhead
-        assert np.isclose(tx[i], 0.)
-        assert np.isclose(ty[i], 0.)
-        assert np.isclose(tz[i], 1.)
-        
+        assert np.isclose(tx[i], 0.0)
+        assert np.isclose(ty[i], 0.0)
+        assert np.isclose(tz[i], 1.0)
+
         # Ensure that inverse-transformed coords match for all sources
         crd_eq2 = np.dot(mat_enu_to_eci, crd_top)
         assert np.allclose(crd_eq, crd_eq2)
-        
+
         # Check that zenith angle is zero when source with RA = lst is overhead
-        az, za = conversions.enu_to_az_za(tx, ty, orientation='astropy')
-        az_uvb, za_uvb = conversions.enu_to_az_za(tx, ty, orientation='uvbeam')
-        assert np.isclose(za[i], 0.)
-        assert np.isclose(za_uvb[i], 0.)
-        
+        az, za = conversions.enu_to_az_za(tx, ty, orientation="astropy")
+        az_uvb, za_uvb = conversions.enu_to_az_za(tx, ty, orientation="uvbeam")
+        assert np.isclose(za[i], 0.0)
+        assert np.isclose(za_uvb[i], 0.0)
+
         # Check that E, N, U are aligned with Az/ZA as expected
-        vec_e = np.array([1., 0., 0.])
-        vec_n = np.array([0., 1., 0.])
-        vec_u = np.array([0., 0., 1.])
-        
+        vec_e = np.array([1.0, 0.0, 0.0])
+        vec_n = np.array([0.0, 1.0, 0.0])
+        vec_u = np.array([0.0, 0.0, 1.0])
+
         # Pointing East (astropy)
-        _az, _za = conversions.enu_to_az_za(vec_e[0], vec_e[1], orientation='astropy')
-        assert np.isclose(_az, 0.5*np.pi)
-        assert np.isclose(_za, 0.5*np.pi)
-        
+        _az, _za = conversions.enu_to_az_za(vec_e[0], vec_e[1], orientation="astropy")
+        assert np.isclose(_az, 0.5 * np.pi)
+        assert np.isclose(_za, 0.5 * np.pi)
+
         # Pointing North (astropy)
-        _az, _za = conversions.enu_to_az_za(vec_n[0], vec_n[1], orientation='astropy')
-        assert np.isclose(_az, 0.)
-        assert np.isclose(_za, 0.5*np.pi)
-        
+        _az, _za = conversions.enu_to_az_za(vec_n[0], vec_n[1], orientation="astropy")
+        assert np.isclose(_az, 0.0)
+        assert np.isclose(_za, 0.5 * np.pi)
+
         # Pointing Up (astropy)
-        _az, _za = conversions.enu_to_az_za(vec_u[0], vec_u[1], orientation='astropy')
-        assert np.isclose(_az, 0.)
-        assert np.isclose(_za, 0.)
-        
+        _az, _za = conversions.enu_to_az_za(vec_u[0], vec_u[1], orientation="astropy")
+        assert np.isclose(_az, 0.0)
+        assert np.isclose(_za, 0.0)
+
         # Pointing East (UVBeam)
-        _az, _za = conversions.enu_to_az_za(vec_e[0], vec_e[1], orientation='uvbeam')
-        assert np.isclose(_az, 0.)
-        assert np.isclose(_za, 0.5*np.pi)
-        
+        _az, _za = conversions.enu_to_az_za(vec_e[0], vec_e[1], orientation="uvbeam")
+        assert np.isclose(_az, 0.0)
+        assert np.isclose(_za, 0.5 * np.pi)
+
         # Pointing North (UVBeam)
-        _az, _za = conversions.enu_to_az_za(vec_n[0], vec_n[1], orientation='uvbeam')
-        assert np.isclose(_az, 0.5*np.pi)
-        assert np.isclose(_za, 0.5*np.pi)
-        
+        _az, _za = conversions.enu_to_az_za(vec_n[0], vec_n[1], orientation="uvbeam")
+        assert np.isclose(_az, 0.5 * np.pi)
+        assert np.isclose(_za, 0.5 * np.pi)
+
         # Pointing Up (UVBeam)
-        _az, _za = conversions.enu_to_az_za(vec_u[0], vec_u[1], orientation='uvbeam')
-        assert np.isclose(_za, 0.)
-        
+        _az, _za = conversions.enu_to_az_za(vec_u[0], vec_u[1], orientation="uvbeam")
+        assert np.isclose(_za, 0.0)
+
         # Do inverse transform and check
         eq_e = np.dot(mat_enu_to_eci, vec_e)
         _tx, _ty, _tz = np.dot(mat_eci_to_enu, eq_e)
-        assert np.isclose(_tx, 1.)
-        assert np.isclose(_ty, 0.)
-        assert np.isclose(_tz, 0.)
-        
+        assert np.isclose(_tx, 1.0)
+        assert np.isclose(_ty, 0.0)
+        assert np.isclose(_tz, 0.0)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -10,7 +10,7 @@ from astropy.time import Time
 from vis_cpu import conversions
 
 np.random.seed(0)
-NTIMES = 4
+NTIMES = 24
 NFREQ = 5
 NPTSRC = 20
 
@@ -86,6 +86,10 @@ def test_equatorial_to_enu():
         # Rotation matrices from ECI <-> ENU
         mat_eci_to_enu = conversions.eci_to_enu_matrix(lst, lat=hera_lat)
         mat_enu_to_eci = conversions.enu_to_eci_matrix(lst, lat=hera_lat)
+
+        # Test that transforms are one anothers' inverse
+        assert np.allclose(np.dot(mat_eci_to_enu, mat_enu_to_eci), np.eye(3))
+        assert np.allclose(np.dot(mat_enu_to_eci, mat_eci_to_enu), np.eye(3))
 
         # Convert to local direction cosines l,m,n
         tx, ty, tz = crd_top = np.dot(mat_eci_to_enu, crd_eq)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -149,3 +149,36 @@ def test_equatorial_to_enu():
         assert np.isclose(_tx, 1.0)
         assert np.isclose(_ty, 0.0)
         assert np.isclose(_tz, 0.0)
+
+
+def test_equatorial_to_eci_coords():
+    """Test correction of ICRS coords to vis_cpu implicit coord system."""
+    nsrcs = 200  # no. of sources to transform
+
+    # Point source equatorial coords in ICRS (randomly distributed)
+    np.random.seed(1)
+    ra = np.random.uniform(low=0.0, high=2.0 * np.pi, size=nsrcs)
+    dec = np.random.uniform(low=-0.5 * np.pi, high=0.5 * np.pi, size=ra.size)
+
+    # HERA location
+    location = EarthLocation.from_geodetic(lat=-30.7215, lon=21.4283, height=1073.0)
+
+    # Observation time
+    obstime = Time("2018-08-31T04:02:30.11", format="isot", scale="utc")
+
+    # Check that function runs
+    new_ra, new_dec = conversions.equatorial_to_eci_coords(
+        ra, dec, obstime, location, unit="rad", frame="icrs"
+    )
+    assert np.all(~np.isnan(new_ra))  # check that there are no NaN values
+    assert np.all(~np.isnan(new_dec))
+
+    # Check that input-checking errors are raised
+    with pytest.raises(TypeError):
+        _ra, _dec = conversions.equatorial_to_eci_coords(
+            ra, dec, "2018-08-31T04:02:30.11", location, unit="rad", frame="icrs"
+        )
+    with pytest.raises(TypeError):
+        _ra, _dec = conversions.equatorial_to_eci_coords(
+            ra, dec, obstime, (-30.7, 21.4, 1073.0), unit="rad", frame="icrs"
+        )

--- a/tests/test_vis_cpu.py
+++ b/tests/test_vis_cpu.py
@@ -18,8 +18,8 @@ ants = {0: (0, 0, 0), 1: (1, 1, 0)}
 def test_vis_cpu():
     """Test basic operation of vis_cpu."""
     # Point source equatorial coords (radians)
-    ra = np.linspace(0.0, np.pi, NPTSRC)
-    dec = np.linspace(0.0, np.pi, NPTSRC)
+    ra = np.linspace(0.0, 2.0 * np.pi, NPTSRC)
+    dec = np.linspace(-0.5 * np.pi, 0.5 * np.pi, NPTSRC)
 
     # Antenna x,y,z positions and frequency array
     antpos = np.array([ants[k] for k in ants.keys()])
@@ -63,8 +63,8 @@ def test_vis_cpu():
 def test_simulate_vis():
     """Test basic operation of simple wrapper around vis_cpu, `simulate_vis`."""
     # Point source equatorial coords (radians)
-    ra = np.linspace(0.0, np.pi, NPTSRC)
-    dec = np.linspace(0.0, np.pi, NPTSRC)
+    ra = np.linspace(0.0, 2.0 * np.pi, NPTSRC)
+    dec = np.linspace(-0.5 * np.pi, 0.5 * np.pi, NPTSRC)
 
     # Antenna x,y,z positions and frequency array
     freq = np.linspace(100.0e6, 120.0e6, NFREQ)  # Hz

--- a/tests/test_vis_cpu.py
+++ b/tests/test_vis_cpu.py
@@ -36,7 +36,7 @@ def test_vis_cpu():
     hera_lat = -30.7215 * np.pi / 180.0
     lsts = np.linspace(0.0, 2.0 * np.pi, NTIMES)
     eq2tops = np.array(
-        [conversions.eci_to_enu_matrix(-lst, lat=hera_lat) for lst in lsts]
+        [conversions.eci_to_enu_matrix(lst, lat=hera_lat) for lst in lsts]
     )
 
     # Create beam models

--- a/tests/test_vis_cpu.py
+++ b/tests/test_vis_cpu.py
@@ -33,10 +33,11 @@ def test_vis_cpu():
     crd_eq = conversions.point_source_crd_eq(ra, dec)
 
     # Get coordinate transforms as a function of LST
+    hera_lat = -30.7215 * np.pi / 180.0
     lsts = np.linspace(0.0, 2.0 * np.pi, NTIMES)
-    eq2tops = conversions.get_eq2tops(
-        lsts, latitude=-30.7215 * np.pi / 180.0
-    )  # HERA latitude
+    eq2tops = np.array(
+        [conversions.eci_to_enu_matrix(-lst, lat=hera_lat) for lst in lsts]
+    )
 
     # Create beam models
     beam = AnalyticBeam(type="gaussian", diameter=14.0)


### PR DESCRIPTION
This PR implements a coordinate conversion function that takes RA and Dec coordinates in a standard system (e.g. ICRS) and converts them to an "Earth-Centered Inertial" frame that the original vis_cpu machinery in hera_sim assumed.

Doing this makes the Alt/Az coordinates of the sources at a given reference time and location, which are eventually used in the vis_cpu calculation, match up very well with the high-precision Astropy calculations. This improved precision persists to times away from the reference time, making it possible to get more accurate results from vis_cpu without having to do the full, computationally-intensive Astropy coordinate conversions for every source for every time sample.