### PR TITLE
Fix assertion failing if arg already has the expected shape.

### DIFF
--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -162,13 +162,14 @@ def vis_cpu(
                 "if polarized=True. Shape wanted: {}; shape given: {}".format((nax, nfeed, nant, bm_pix, bm_pix), bm_cube.shape)
             )
         else:
-            assert bm_cube.shape == (
-                nant,
-                bm_pix,
-                bm_pix,
-            ), "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) if polarized=False. \
-Shape wanted: {}; shape given: {}".format((nant, bm_pix, bm_pix), bm_cube.shape)
-            bm_cube = bm_cube[np.newaxis, np.newaxis]
+            try:
+                bm_cube.shape == (1, 1, nant, bm_pix, bm_pix)
+            except:
+                assert bm_cube.shape == (nant, bm_pix, bm_pix), (
+                    "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) if polarized=False. "
+                    "Shape wanted: {}; shape given: {}".format((nant, bm_pix, bm_pix), bm_cube.shape)
+                )
+                bm_cube = bm_cube[np.newaxis, np.newaxis]
     else:
         assert len(beam_list) == nant, "beam_list must have length nant"
 

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -159,15 +159,15 @@ def vis_cpu(
         if polarized:
             assert bm_cube.shape == (nax, nfeed, nant, bm_pix, bm_pix), (
                 "bm_cube must have shape (NAXES, NFEEDS, NANTS, BM_PIX, BM_PIX) "
-                "if polarized=True. Shape wanted: {}; shape given: {}".format((nax, nfeed, nant, bm_pix, bm_pix), bm_cube.shape)
+                "if polarized=True. Shape wanted: {}; shape given: {}".format(
+                    (nax, nfeed, nant, bm_pix, bm_pix), bm_cube.shape)
             )
         else:
-            try:
-                bm_cube.shape == (1, 1, nant, bm_pix, bm_pix)
-            except:
+            if bm_cube.shape != (1, 1, nant, bm_pix, bm_pix):
                 assert bm_cube.shape == (nant, bm_pix, bm_pix), (
-                    "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) if polarized=False. "
-                    "Shape wanted: {}; shape given: {}".format((nant, bm_pix, bm_pix), bm_cube.shape)
+                    "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) or (1, 1, nant, bm_pix, bm_pix) if polarized=False. "
+                    "Shape wanted: {}; shape given: {}".format(
+                        (nant, bm_pix, bm_pix), bm_cube.shape)
                 )
                 bm_cube = bm_cube[np.newaxis, np.newaxis]
     else:
@@ -240,10 +240,10 @@ def vis_cpu(
         # Compute visibilities using product of complex voltages (upper triangle).
         # Input arrays have shape (Nax, Nfeed, [Nants], Nsrcs
         for i in range(len(antpos)):
-            vis[:, :, t, i : i + 1, i:] = np.einsum(
+            vis[:, :, t, i: i + 1, i:] = np.einsum(
                 "ijln,jkmn->iklm",
-                A_s[:, :, i : i + 1].conj()
-                * v[np.newaxis, np.newaxis, i : i + 1].conj(),
+                A_s[:, :, i: i + 1].conj()
+                * v[np.newaxis, np.newaxis, i: i + 1].conj(),
                 A_s[:, :, i:] * v[np.newaxis, np.newaxis, i:],
                 optimize=True,
             )

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -167,7 +167,7 @@ def vis_cpu(
                 bm_pix,
                 bm_pix,
             ), "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) if polarized=False. \
-                Shape wanted: {}; shape given: {}".format((nant, bm_pix, bm_pix), bm_cube.shape)
+Shape wanted: {}; shape given: {}".format((nant, bm_pix, bm_pix), bm_cube.shape)
             bm_cube = bm_cube[np.newaxis, np.newaxis]
     else:
         assert len(beam_list) == nant, "beam_list must have length nant"

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -160,14 +160,16 @@ def vis_cpu(
             assert bm_cube.shape == (nax, nfeed, nant, bm_pix, bm_pix), (
                 "bm_cube must have shape (NAXES, NFEEDS, NANTS, BM_PIX, BM_PIX) "
                 "if polarized=True. Shape wanted: {}; shape given: {}".format(
-                    (nax, nfeed, nant, bm_pix, bm_pix), bm_cube.shape)
+                    (nax, nfeed, nant, bm_pix, bm_pix), bm_cube.shape
+                )
             )
         else:
             if bm_cube.shape != (1, 1, nant, bm_pix, bm_pix):
                 assert bm_cube.shape == (nant, bm_pix, bm_pix), (
                     "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) or (1, 1, nant, bm_pix, bm_pix) if polarized=False. "
                     "Shape wanted: {}; shape given: {}".format(
-                        (nant, bm_pix, bm_pix), bm_cube.shape)
+                        (nant, bm_pix, bm_pix), bm_cube.shape
+                    )
                 )
                 bm_cube = bm_cube[np.newaxis, np.newaxis]
     else:
@@ -240,10 +242,10 @@ def vis_cpu(
         # Compute visibilities using product of complex voltages (upper triangle).
         # Input arrays have shape (Nax, Nfeed, [Nants], Nsrcs
         for i in range(len(antpos)):
-            vis[:, :, t, i: i + 1, i:] = np.einsum(
+            vis[:, :, t, i : i + 1, i:] = np.einsum(
                 "ijln,jkmn->iklm",
-                A_s[:, :, i: i + 1].conj()
-                * v[np.newaxis, np.newaxis, i: i + 1].conj(),
+                A_s[:, :, i : i + 1].conj()
+                * v[np.newaxis, np.newaxis, i : i + 1].conj(),
                 A_s[:, :, i:] * v[np.newaxis, np.newaxis, i:],
                 optimize=True,
             )

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -159,14 +159,15 @@ def vis_cpu(
         if polarized:
             assert bm_cube.shape == (nax, nfeed, nant, bm_pix, bm_pix), (
                 "bm_cube must have shape (NAXES, NFEEDS, NANTS, BM_PIX, BM_PIX) "
-                "if polarized=True."
+                "if polarized=True. Shape wanted: {}; shape given: {}".format((nax, nfeed, nant, bm_pix, bm_pix), bm_cube.shape)
             )
         else:
             assert bm_cube.shape == (
                 nant,
                 bm_pix,
                 bm_pix,
-            ), "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) if polarized=False."
+            ), "bm_cube must have shape (NANTS, BM_PIX, BM_PIX) if polarized=False. \
+                Shape wanted: {}; shape given: {}".format((nant, bm_pix, bm_pix), bm_cube.shape)
             bm_cube = bm_cube[np.newaxis, np.newaxis]
     else:
         assert len(beam_list) == nant, "beam_list must have length nant"

--- a/tests/test_vis_cpu.py
+++ b/tests/test_vis_cpu.py
@@ -59,6 +59,34 @@ def test_vis_cpu():
 
         assert np.all(~np.isnan(_vis))  # check that there are no NaN values
 
+    # Check that a wrongly-sized beam cube raises an error
+    # for both polarized and unpolarized sims
+    nb_bm_pix = beam_cube.shape[-1]
+    broken_beam_cube_for_unpol = np.empty((2, 2, 2, nb_bm_pix, nb_bm_pix))
+    broken_beam_cube_for_pol = np.empty((1, 2, 2, nb_bm_pix, nb_bm_pix))
+    with pytest.raises(AssertionError):
+        vis_cpu(
+            antpos,
+            freq[0],
+            eq2tops,
+            crd_eq,
+            I_sky[:, 0],
+            bm_cube=broken_beam_cube_for_unpol,
+            precision=1,
+            polarized=False,
+        )
+    with pytest.raises(AssertionError):
+        vis_cpu(
+            antpos,
+            freq[0],
+            eq2tops,
+            crd_eq,
+            I_sky[:, 0],
+            bm_cube=broken_beam_cube_for_pol,
+            precision=1,
+            polarized=True,
+        )
+
 
 def test_simulate_vis():
     """Test basic operation of simple wrapper around vis_cpu, `simulate_vis`."""


### PR DESCRIPTION
An `assert` was checking if `bm_cube.shape == (nant, bm_pix, bm_pix)`, _then_ doing `bm_cube = bm_cube[np.newaxis, np.newaxis]`, causing a `hera_sim` test to fail because the provided `bm_cube` already had shape `(1, 1, nant, bm_pix, bm_pix)`.

-> Test first if `bm_cube` already has shape `(1, 1, nant, bm_pix, bm_pix)`.

(Also, improve info given by the `AssertionError` message by explicitly giving the wanted/given shapes.)