### PR TITLE
Fix order of parameters passed to .interp()

### DIFF
--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -230,7 +230,8 @@ def vis_cpu(
             # Primary beam pattern using direct interpolation of UVBeam object
             az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation="uvbeam")
             for i in range(nant):
-                interp_beam = beam_list[i].interp(az, za, np.atleast_1d(freq))[0]
+                interp_beam = beam_list[i].interp(
+                    az_array=az, za_array=za, freq_array=np.atleast_1d(freq))[0]
 
                 if polarized:
                     A_s[:, :, i] = interp_beam[:, 0, :, 0, :]  # spw=0 and freq=0

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -231,7 +231,8 @@ def vis_cpu(
             az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation="uvbeam")
             for i in range(nant):
                 interp_beam = beam_list[i].interp(
-                    az_array=az, za_array=za, freq_array=np.atleast_1d(freq))[0]
+                    az_array=az, za_array=za, freq_array=np.atleast_1d(freq)
+                )[0]
 
                 if polarized:
                     A_s[:, :, i] = interp_beam[:, 0, :, 0, :]  # spw=0 and freq=0


### PR DESCRIPTION
Very small fix to ensure that the `az_array`, `za_array` and `freq_array` parameters are correctly passed on to .interp() (the order is different between `pyuvdata.UVBeam` and `hera_sim.beams.py`)