### PR TITLE
doc: simple update to readme install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ vis_cpu
     :target: https://github.com/psf/black
 
 
-Fast visibility simulator with interface to CPU and GPU
+Fast visibility simulator with interface to CPU and GPU.
 
 
 Description
@@ -24,7 +24,7 @@ A longer description of your project goes here...
 Installation
 ============
 Merely do ``pip install vis_cpu``. If you want to use the GPU functions, install
-with ``pip install vis_cpu.[gpu]``.
+with ``pip install vis_cpu[gpu]``.
 
 Developers
 ==========


### PR DESCRIPTION
In response to @JianrongTan's issue, this just updates the README installation instructions to remove the incorrect dot.
