### PR TITLE
fix: correct handling of polarizations from UVBeam

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     numpy
     scipy
     astropy
+    typing_extensions ; python_version<'3.8'
 
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
@@ -123,6 +124,7 @@ ignore =
     F401
     E231
     C901
+    D401
 
 max-line-length = 88
 # Should be 18.

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -108,7 +108,9 @@ def vis_cpu(
     beam_list : list of UVBeam, optional
         If specified, evaluate primary beam values directly using UVBeam
         objects instead of using pixelized beam maps (``bm_cube`` will be
-        ignored if ``beam_list`` is not ``None``).
+        ignored if ``beam_list`` is not ``None``). Note that if `polarized` is True,
+        these beams must be efield beams, and conversely they must be power beams
+        with a single polarization (either XX or YY).
     precision : int, optional
         Which precision level to use for floats and complex numbers.
         Allowed values:
@@ -116,13 +118,7 @@ def vis_cpu(
         - 2: float64, complex128
     polarized : bool, optional
         Whether to simulate a full polarized response in terms of nn, ne, en,
-        ee visibilities.
-
-        If False, a single Jones matrix element will be used, corresponding to
-        the (phi, e) element, i.e. the [0,0,1] component of the beam returned
-        by its ``interp()`` method.
-
-        See Eq. 6 of Kohn+ (arXiv:1802.04151) for notation.
+        ee visibilities. See Eq. 6 of Kohn+ (arXiv:1802.04151) for notation.
         Default: False.
 
     Returns
@@ -182,6 +178,20 @@ def vis_cpu(
                 )
                 bm_cube = bm_cube[np.newaxis, np.newaxis]
     else:
+        if polarized and any(b.beam_type != "efield" for b in beam_list):
+            raise ValueError("beam type must be efield if using polarized=True")
+        elif not polarized and any(
+            (
+                b.beam_type != "power"
+                or getattr(b, "Npols", 1) > 1
+                or b.polarization_array[0] not in [-5, -6]
+            )
+            for b in beam_list
+        ):
+            raise ValueError(
+                "beam type must be power and have only one pol (either xx or yy) if polarized=False"
+            )
+
         assert len(beam_list) == nant, "beam_list must have length nant"
 
     # Intensity distribution (sqrt) and antenna positions. Does not support
@@ -227,6 +237,7 @@ def vis_cpu(
                                 ty, tx, grid=False
                             )
         else:
+
             # Primary beam pattern using direct interpolation of UVBeam object
             az, za = conversions.enu_to_az_za(enu_e=tx, enu_n=ty, orientation="uvbeam")
             for i in range(nant):
@@ -237,9 +248,9 @@ def vis_cpu(
                 if polarized:
                     A_s[:, :, i] = interp_beam[:, 0, :, 0, :]  # spw=0 and freq=0
                 else:
-                    A_s[:, :, i] = interp_beam[
-                        0, 0, 1, :, :
-                    ]  # (phi, e) == 'xx' component
+                    # Here we have already asserted that the beam is a power beam and
+                    # has only one polarization, so we just evaluate that one.
+                    A_s[:, :, i] = interp_beam[0, 0, 0, :, :]
 
         # Horizon cut
         A_s = np.where(tz > 0, A_s, 0)

--- a/src/vis_cpu/wrapper.py
+++ b/src/vis_cpu/wrapper.py
@@ -1,5 +1,6 @@
 """Simple example wrapper for basic usage of vis_cpu."""
 import numpy as np
+from pyuvdata.uvbeam import UVBeam
 
 from . import conversions, vis_cpu
 
@@ -17,6 +18,7 @@ def simulate_vis(
     polarized=False,
     precision=1,
     latitude=-30.7215 * np.pi / 180.0,
+    use_feed="x",
 ):
     """
     Run a basic simulation using ``vis_cpu``.
@@ -104,11 +106,16 @@ def simulate_vis(
     if pixel_beams:
         beam_pix = [
             conversions.uvbeam_to_lm(
-                beam, freqs, n_pix_lm=beam_npix, polarized=polarized
+                beam, freqs, n_pix_lm=beam_npix, polarized=polarized, use_feed=use_feed
             )
             for beam in beams
         ]
         beam_cube = np.array(beam_pix)
+    else:
+        beams = [
+            conversions.prepare_beam(beam, polarized=polarized, use_feed=use_feed)
+            for beam in beams
+        ]
 
     # Run vis_cpu with pixel beams
     if polarized:

--- a/tests/test_beams.py
+++ b/tests/test_beams.py
@@ -37,6 +37,20 @@ class EllipticalBeam(object):
         self.ystretch = ystretch
         self.rotation = rotation
 
+    @property
+    def beam_type(self) -> str:
+        """Whether the beam is `power` or `efield`."""
+        return self.base_beam.beam_type
+
+    def efield_to_power(self):
+        """Convert from efield to power beam."""
+        self.base_beam.efield_to_power()
+
+    @property
+    def polarization_array(self):
+        """The polarization array of the base beam."""
+        return self.base_beam.polarization_array
+
     def interp(self, az_array, za_array, freq_array):
         """Evaluate the beam after applying shearing, stretching, or rotation.
 
@@ -111,7 +125,11 @@ def test_beam_interpolation():
 
     # Get Gaussian beam and transform into an elliptical version
     base_beam = AnalyticBeam("gaussian", diameter=14.0)
-    beam_analytic = EllipticalBeam(base_beam, xstretch=2.2, ystretch=1.0, rotation=40.0)
+    beam_analytic = base_beam  # EllipticalBeam(base_beam, xstretch=2.2, ystretch=1.0, rotation=40.0)
+    beam_analytic = conversions.prepare_beam(
+        beam_analytic, polarized=False, use_feed="x"
+    )
+
     beam_list = [beam_analytic, beam_analytic]
 
     # Construct pixel beam from analytic beam
@@ -164,7 +182,7 @@ def test_beam_interpolation():
 
         # Check that results are close (they should be for 1000^2 pixel-beams
         # if the elliptical beams are both oriented the same way)
-        assert np.allclose(vis_pix, vis_analytic, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(vis_pix, vis_analytic, rtol=1e-5, atol=1e-5)
 
 
 def test_beam_interpolation_pol():

--- a/tests/test_vis_cpu.py
+++ b/tests/test_vis_cpu.py
@@ -130,7 +130,11 @@ def test_vis_cpu():
         )
 
 
-def test_simulate_vis():
+@pytest.mark.parametrize(
+    "pixel_beams,polarized",
+    [(True, False), (False, False), (False, True), (True, True)],
+)
+def test_simulate_vis(pixel_beams, polarized):
     """Test basic operation of simple wrapper around vis_cpu, `simulate_vis`."""
     # Point source equatorial coords (radians)
     ra = np.linspace(0.0, 2.0 * np.pi, NPTSRC)
@@ -158,57 +162,9 @@ def test_simulate_vis():
         freq,
         lsts,
         beams=[beam, beam],
-        pixel_beams=True,
+        pixel_beams=pixel_beams,
         beam_npix=63,
-        polarized=False,
-        precision=1,
-        latitude=-30.7215 * np.pi / 180.0,
-    )
-    assert np.all(~np.isnan(vis))  # check that there are no NaN values
-
-    # Run vis_cpu with UVBeam beams
-    vis = simulate_vis(
-        ants,
-        I_sky,
-        ra,
-        dec,
-        freq,
-        lsts,
-        beams=[beam, beam],
-        pixel_beams=False,
-        polarized=False,
-        precision=1,
-        latitude=-30.7215 * np.pi / 180.0,
-    )
-    assert np.all(~np.isnan(vis))  # check that there are no NaN values
-
-    # Run vis_cpu with UVBeam beams (polarized mode)
-    vis = simulate_vis(
-        ants,
-        I_sky,
-        ra,
-        dec,
-        freq,
-        lsts,
-        beams=[beam, beam],
-        pixel_beams=False,
-        polarized=True,
-        precision=1,
-        latitude=-30.7215 * np.pi / 180.0,
-    )
-    assert np.all(~np.isnan(vis))  # check that there are no NaN values
-
-    # Run vis_cpu with pixel beams (polarized mode)
-    vis = simulate_vis(
-        ants,
-        I_sky,
-        ra,
-        dec,
-        freq,
-        lsts,
-        beams=[beam, beam],
-        pixel_beams=True,
-        polarized=True,
+        polarized=polarized,
         precision=1,
         latitude=-30.7215 * np.pi / 180.0,
     )


### PR DESCRIPTION
This PR updates the behaviour of vis_cpu to be more consistent.
In particular, when ``polarized=False``, we explicitly take the sqrt
of the power beam for a particular feed. We raise errors for incompatible
inputs.

BREAKING CHANGE: previous inputs for the beam will now sometimes
raise errors, as they were inconsistent. In particular, input
``beam_list`` to ``vis_cpu`` must be efield type if using `polarized=True`
and `power` type if not.