### PR TITLE
perf: only integrate over sources above horizon

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Changed
 
 - Enhanced performance by allowing unique beams only to be passed (no breaking API
   change).
+- Enhanced performance of ``vis_cpu`` by only using sources above horizon, and changing
+  some array multiplication strategies (factor of ~3).
 
 Version 0.2.3
 =============

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -13,6 +13,7 @@ from . import conversions
 try:
     profile
 except NameError:
+
     def profile(fnc):
         """No-op profiling decorator."""
         return fnc
@@ -260,7 +261,7 @@ def vis_cpu(
         A_s = np.zeros((nax, nfeed, nbeam, nsrcs_up), dtype=complex_dtype)
         tau = np.zeros((nant, nsrcs_up), dtype=real_dtype)
         v = np.zeros((nant, nsrcs_up), dtype=complex_dtype)
-        
+
         # Primary beam response
         if beam_list is None:
             # Primary beam pattern using pixelized primary beam
@@ -270,7 +271,7 @@ def vis_cpu(
                     for p2 in range(nfeed):
                         # The beam pixel grid has been reshaped in the order
                         # ty,tx, which implies m,l order
-                        
+
                         re = splines_re[p1][p2][i](ty, tx, grid=False)
 
                         if complex_bm_cube:
@@ -317,7 +318,7 @@ def vis_cpu(
 
         for i in range(len(antpos)):
             vis[:, :, t, i : i + 1, i:] = np.einsum(
-                "ijln,jkmn->iklm", v[:, :, i:i+1].conj(), v[:, :, i:], optimize=True
+                "ijln,jkmn->iklm", v[:, :, i : i + 1].conj(), v[:, :, i:], optimize=True
             )
 
     # Return visibilities with or without multiple polarization channels

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -8,6 +8,16 @@ from typing import Optional, Sequence
 
 from . import conversions
 
+# This enables us to put in profile decorators that will be no-ops if no profiling
+# library is being used.
+try:
+    profile
+except NameError:
+
+    def profile(fnc):
+        """No-op profiling decorator."""
+        return fnc
+
 
 def construct_pixel_beam_spline(bm_cube):
     """Construct bivariate spline for pixelated beams for all antennas.
@@ -60,6 +70,7 @@ def construct_pixel_beam_spline(bm_cube):
     return splines
 
 
+@profile
 def vis_cpu(
     antpos: np.ndarray,
     freq: float,

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -313,12 +313,11 @@ def vis_cpu(
 
         # Compute visibilities using product of complex voltages (upper triangle).
         # Input arrays have shape (Nax, Nfeed, [Nants], Nsrcs
+        v = A_s[:, :, beam_idx] * v[np.newaxis, np.newaxis, :]
+
         for i in range(len(antpos)):
-            bm = beam_idx[i]
-            x = (A_s[:, :, bm : bm + 1] * v[np.newaxis, np.newaxis, i : i + 1]).conj()
-            y = A_s[:, :, beam_idx[i:]] * v[np.newaxis, np.newaxis, i:]
             vis[:, :, t, i : i + 1, i:] = np.einsum(
-                "ijln,jkmn->iklm", x, y, optimize=True
+                "ijln,jkmn->iklm", v[:, :, i:i+1].conj(), v[:, :, i:], optimize=True
             )
 
     # Return visibilities with or without multiple polarization channels

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -239,7 +239,7 @@ def vis_cpu(
 
     im = np.zeros(nsrcs, dtype=real_dtype) if complex_bm_cube else 0
     re = np.zeros(nsrcs, dtype=real_dtype)
-    
+
     # Loop over time samples
     for t, eq2top in enumerate(eq2tops.astype(real_dtype)):
         # Dot product converts ECI cosines (i.e. from RA and Dec) into ENU
@@ -250,7 +250,6 @@ def vis_cpu(
         tx = tx[above_horizon]
         ty = ty[above_horizon]
 
-        
         # Primary beam response
         if beam_list is None:
             # Primary beam pattern using pixelized primary beam
@@ -265,7 +264,9 @@ def vis_cpu(
                         re[above_horizon] = splines_re[p1][p2][i](ty, tx, grid=False)
 
                         if complex_bm_cube:
-                            im[above_horizon] = 1.0j * splines_im[p1][p2][i](ty, tx, grid=False)
+                            im[above_horizon] = 1.0j * splines_im[p1][p2][i](
+                                ty, tx, grid=False
+                            )
 
                         A_s[p1, p2, beam_idx == i] = re + im
         else:
@@ -286,7 +287,9 @@ def vis_cpu(
                     # Here we have already asserted that the beam is a power beam and
                     # has only one polarization, so we just evaluate that one.
                     for ant in range(nant):
-                        A_s[:, :, beam_idx[ant], above_horizon] = np.sqrt(interp_beam[0, 0, 0, 0, :])
+                        A_s[:, :, beam_idx[ant], above_horizon] = np.sqrt(
+                            interp_beam[0, 0, 0, 0, :]
+                        )
 
         # Check for invalid beam values
         if np.any(np.isinf(A_s)) or np.any(np.isnan(A_s)):

--- a/src/vis_cpu/vis_cpu.py
+++ b/src/vis_cpu/vis_cpu.py
@@ -269,7 +269,6 @@ def vis_cpu(
                             )
 
                         A_s[p1, p2, beam_idx == i] = re + im
-            print("CUBE: ", np.mean(A_s))
         else:
 
             # Primary beam pattern using direct interpolation of UVBeam object
@@ -287,9 +286,8 @@ def vis_cpu(
                     interp_beam = np.sqrt(interp_beam[0, 0, 0, 0, :])
 
                 for ant in range(nant):
-                    A_s[:, :, beam_idx[ant], above_horizon] = interp_beam
-
-            print("ANALYTIC: ", np.mean(A_s))
+                    if beam_idx[ant] == i:
+                        A_s[:, :, ant, above_horizon] = interp_beam
 
         # Check for invalid beam values
         if np.any(np.isinf(A_s)) or np.any(np.isnan(A_s)):


### PR DESCRIPTION
Rather than zero out the beam for sources below the horizon, restrict the calculations to only consider sources above the horizon wherever possible. This should provide a decent amount of computational savings for simulations with a large number of sources.

I should note that although I expect this to give us a decent speedup, I would like to see some profiling done before merging, just to be sure that it actually does give a significant speedup. I'm a little worried about things in the python->C land that have to do with array ordering and efficiency, but I'm admittedly not well-versed enough in that (and what numpy actually does under the hood) to determine whether that's actually something worth worrying about here.