### PR TITLE
test: use frame kwarg for tests SkyModels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Fixed
 - Better handling of errors when GPUs are present but currently unavailable for some
   reason.
 
+Tests
+-----
+
+- Correct formation of SkyModel for ``pyradiosky>=0.3.0`` in tests.
+
 Version 1.0.1
 =============
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -138,6 +138,7 @@ def get_standard_sim_params(
         name=[str(i) for i in range(len(ra_dec))],
         ra=Longitude(ra_dec[:, 0], "rad"),
         dec=Latitude(ra_dec[:, 1], "rad"),
+        frame="icrs",
         spectral_type="spectral_index",
         spectral_index=sources[:, 3],
         stokes=stokes * un.Jy,


### PR DESCRIPTION
<!--
Thank you for creating a PR on vis_cpu!

Please read through the following and check the boxes to ensure
your PR meets our coding standards and that it follows the
correct pathways for testing and deployment.
-->

# Description
<!-- Write a brief description of what the new feature does, and how a review could take it for a spin -->

Simply updates the `SkyModel()` call in tests to use the `frame` keyword.

# Issues
<!-- If this feature is in response to any open issues, reference them here by adding a line for each, with "Fixes #xx".
     Otherwise remove this section.
-->

# Checklist
I have

- [x] Added a test covering your new feature adequately?
- [x] Added a docstring (or note to a docstring) describing your feature?
- [ ] (Optional): Added a tutorial / section to a tutorial showing usage of your new feature?
- [x] **Important**: this feature does *not* break API compatibility.
