### PR TITLE
Add functions for coherency rotation

### DIFF
--- a/src/matvis/coordinates.py
+++ b/src/matvis/coordinates.py
@@ -193,8 +193,7 @@ def point_source_crd_eq(ra, dec):
     Returns
     -------
     array_like
-        Equatorial coordinates of sources, in Cartesian
-        system. Shape=(3, NSRCS).
+        Equatorial coordinates of sources, in Cartesian system. Shape=(3, NSRCS).
     """
     xp = get_array_module(ra, dec)
     return xp.asarray([xp.cos(ra) * xp.cos(dec), xp.cos(dec) * xp.sin(ra), xp.sin(dec)])
@@ -408,12 +407,6 @@ def vecs2rot(r1, r2):
     -------
     R : ndarray, shape (3, 3, N)
         Rotation matrices such that R[..., i] @ r1[:, i] = r2[:, i].
-
-    Method
-    ------
-    - rotation axis = (r1 x r2) / |r1 x r2|
-    - rotation angle = arctan2(‖r1xr2‖, r1·r2)
-    - use Rodrigues’ formula via `axis_angle_rotation_matrix`.
     """
     xp = get_array_module(r1, r2)
 
@@ -484,8 +477,9 @@ def spherical_basis_vector_rotation_matrix(theta, phi, rotation_matrix, beta, al
     -------
     bmat : ndarray, shape (2,2,...)
         2×2 rotation matrices in the spherical basis:
-        [[ cos X,  sin X],
-         [-sin X,  cos X]],
+            [[ cos X,  sin X],
+            [-sin X,  cos X]],
+
         where X is the angle between the two basis sets.
     """
     xp = get_array_module(theta, phi)

--- a/src/matvis/coordinates.py
+++ b/src/matvis/coordinates.py
@@ -289,8 +289,8 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
 
 def calc_coherency_rotation(ra, dec, alt, az, location, time):
     """
-    Compute the rotation matrix needed for time-dependent coherency calculation. 
-    
+    Compute the rotation matrix needed for time-dependent coherency calculation.
+
     This function computes the rotation matrix needed to rotate a source's coherency
     from equatorial (RA/Dec) frame into the local alt/az frame. Adopted
     from the pyradiosky coherency calculation, but modified for better vectorization.
@@ -340,8 +340,8 @@ def calc_coherency_rotation(ra, dec, alt, az, location, time):
 
 def _calc_rotation_matrix(ra, dec, alt, az, time, location):
     """
-    Build the full 3×3 rotation matrix between (RA, Dec) and (alt, az). 
-    
+    Build the full 3×3 rotation matrix between (RA, Dec) and (alt, az).
+
     This function build the rotation matrix that carries unit vectors
     at (RA, Dec) in ICRS into unit vectors at (alt,az) in the local altaz frame.
     Adopted from pyradiosky.
@@ -396,7 +396,7 @@ def _calc_rotation_matrix(ra, dec, alt, az, time, location):
 def vecs2rot(r1, r2):
     """
     Construct an axis-angle rotation matrix R that carries vector r1 to r2.
-    
+
     This function has been adopted from adopted from pyradiosky.
 
     Parameters
@@ -470,7 +470,7 @@ def axis_angle_rotation_matrix(axis, angle):
 def spherical_basis_vector_rotation_matrix(theta, phi, rotation_matrix, beta, alpha):
     """
     Get the rotation matrix for vectors in theta/phi basis to a new reference frame.
-    
+
     Parameters
     ----------
     theta, phi : array_like
@@ -506,7 +506,7 @@ def spherical_basis_vector_rotation_matrix(theta, phi, rotation_matrix, beta, al
 
 def _calc_average_rotation_matrix(time, telescope_location):
     """
-    Compute the rigid-body rotation from ICRS (x,y,z) axes. 
+    Compute the rigid-body rotation from ICRS (x,y,z) axes.
 
     Parameters
     ----------

--- a/src/matvis/coordinates.py
+++ b/src/matvis/coordinates.py
@@ -464,8 +464,8 @@ def axis_angle_rotation_matrix(axis, angle):
 def spherical_basis_vector_rotation_matrix(theta, phi, rotation_matrix, beta, alpha):
     """
     Compute the 2×2 rotation matrix that carries the spherical
-    basis vectors (θ̂, φ̂) at (theta,phi) in one frame into
-    the basis vectors at (beta,alpha) in the rotated frame.
+    basis vectors (θ̂, φ̂) at (theta, phi) in one frame into
+    the basis vectors at (beta, alpha) in the rotated frame.
     Adopted from pyradiosky.
 
     Parameters
@@ -489,10 +489,10 @@ def spherical_basis_vector_rotation_matrix(theta, phi, rotation_matrix, beta, al
     th = theta_hat(theta, phi)
     ph = phi_hat(theta, phi)
 
-    # rotate the new-frame θ̂ into original-frame coordinates
+    # rotate the new-frame theta hat into original-frame coordinates
     bh = np.einsum("ba...,b...->a...", rotation_matrix, theta_hat(beta, alpha))
 
-    # project rotated θ̂ onto original θ̂ and φ̂ to get the mixing angle
+    # project rotated theta hat onto original theta hat and phi hat to get the mixing angle
     cosX = np.einsum("a...,a...->...", bh, th)
     sinX = np.einsum("a...,a...->...", bh, ph)
 

--- a/src/matvis/coordinates.py
+++ b/src/matvis/coordinates.py
@@ -289,7 +289,9 @@ def equatorial_to_eci_coords(ra, dec, obstime, location, unit="rad", frame="icrs
 
 def calc_coherency_rotation(ra, dec, alt, az, location, time):
     """
-    Compute the rotation matrix needed to rotate a source's coherency
+    Compute the rotation matrix needed for time-dependent coherency calculation. 
+    
+    This function computes the rotation matrix needed to rotate a source's coherency
     from equatorial (RA/Dec) frame into the local alt/az frame. Adopted
     from the pyradiosky coherency calculation, but modified for better vectorization.
 
@@ -338,7 +340,9 @@ def calc_coherency_rotation(ra, dec, alt, az, location, time):
 
 def _calc_rotation_matrix(ra, dec, alt, az, time, location):
     """
-    Build the full 3×3 rotation matrix that carries unit vectors
+    Build the full 3×3 rotation matrix between (RA, Dec) and (alt, az). 
+    
+    This function build the rotation matrix that carries unit vectors
     at (RA, Dec) in ICRS into unit vectors at (alt,az) in the local altaz frame.
     Adopted from pyradiosky.
 
@@ -392,7 +396,8 @@ def _calc_rotation_matrix(ra, dec, alt, az, time, location):
 def vecs2rot(r1, r2):
     """
     Construct an axis-angle rotation matrix R that carries vector r1 to r2.
-    Adopted from pyradiosky.
+    
+    This function has been adopted from adopted from pyradiosky.
 
     Parameters
     ----------
@@ -406,8 +411,8 @@ def vecs2rot(r1, r2):
 
     Method
     ------
-    - rotation axis = (r1 × r2) / |r1 × r2|
-    - rotation angle = arctan2(‖r1×r2‖, r1·r2)
+    - rotation axis = (r1 x r2) / |r1 x r2|
+    - rotation angle = arctan2(‖r1xr2‖, r1·r2)
     - use Rodrigues’ formula via `axis_angle_rotation_matrix`.
     """
     xp = get_array_module(r1, r2)
@@ -464,11 +469,8 @@ def axis_angle_rotation_matrix(axis, angle):
 
 def spherical_basis_vector_rotation_matrix(theta, phi, rotation_matrix, beta, alpha):
     """
-    Compute the 2×2 rotation matrix that carries the spherical
-    basis vectors (θ̂, φ̂) at (theta, phi) in one frame into
-    the basis vectors at (beta, alpha) in the rotated frame.
-    Adopted from pyradiosky.
-
+    Get the rotation matrix for vectors in theta/phi basis to a new reference frame.
+    
     Parameters
     ----------
     theta, phi : array_like
@@ -504,8 +506,7 @@ def spherical_basis_vector_rotation_matrix(theta, phi, rotation_matrix, beta, al
 
 def _calc_average_rotation_matrix(time, telescope_location):
     """
-    Compute the rigid-body rotation from ICRS (x,y,z) axes to the
-    local altaz axes at the given time and site, then orthogonalize it.
+    Compute the rigid-body rotation from ICRS (x,y,z) axes. 
 
     Parameters
     ----------

--- a/src/matvis/core/coords.py
+++ b/src/matvis/core/coords.py
@@ -96,7 +96,15 @@ class CoordinateRotation(ABC):
         )
 
     def select_chunk(self, chunk: int, t: int):
-        """Set the chunk of coordinates to rotate."""
+        """
+        Set the chunk of coordinates to rotate.
+
+        This function sets the chunk of coordinates to rotate. It is used following the
+        `rotate` method and returns a chunk of sources coordinates and fluxes for the sources
+        above the horizon. If the sky model is polarized, it also rotates the frame of the
+        coherency matrix to the alt/az frame. The chunk size is determined by the `chunk_size`
+        parameter.
+        """
         # The last index can be larger than the actual size of the array without error.
         slc = slice(chunk * self.chunk_size, (chunk + 1) * self.chunk_size)
 

--- a/src/matvis/cpu/cpu.py
+++ b/src/matvis/cpu/cpu.py
@@ -226,7 +226,7 @@ def simulate(
         coords.rotate(t)
 
         for c in range(nchunks):
-            crd_top, flux_sqrt, nn = coords.select_chunk(c)
+            crd_top, flux_sqrt, nn = coords.select_chunk(c, t)
             logdebug("crdtop", crd_top[:, :nn])
             logdebug("Isqrt", flux_sqrt[:nn])
 

--- a/src/matvis/gpu/gpu.py
+++ b/src/matvis/gpu/gpu.py
@@ -190,7 +190,7 @@ def simulate(
             stream.use()
             event["start"].record(stream)
 
-            crdtop, Isqrt, nsrcs_up = coords.select_chunk(c)
+            crdtop, Isqrt, nsrcs_up = coords.select_chunk(c, t)
             logdebug("crdtop", crdtop)
             logdebug("Isqrt", Isqrt)
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -194,7 +194,6 @@ def test_equatorial_to_eci_coords():
 
 def test_coherency_calc():
     """Test calculation of coherency matrix."""
-
     params, sky_model, *_ = get_standard_sim_params(
         use_analytic_beam=False,
         polarized=True,

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -192,16 +192,17 @@ def test_equatorial_to_eci_coords():
         )
 
 
-def test_coherency_calc():
+@pytest.mark.parametrize("first_source_antizenith", [True, False])
+def test_coherency_calc(first_source_antizenith):
     """Test calculation of coherency matrix."""
     params, sky_model, *_ = get_standard_sim_params(
         use_analytic_beam=False,
         polarized=True,
         nsource=NPTSRC,
         ntime=NTIMES,
+        first_source_antizenith=first_source_antizenith,
     )
 
-    # Generate random point sources
     for time in params["times"]:
         sky_model.update_positions(
             time=time, telescope_location=params["telescope_loc"]

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -4,9 +4,11 @@ import pytest
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
 from astropy.coordinates.builtin_frames import AltAz
 from astropy.time import Time
+from astropy.units import Quantity
+from pyradiosky import SkyModel
 
 from matvis import coordinates
 from matvis._test_utils import get_standard_sim_params
@@ -193,7 +195,8 @@ def test_equatorial_to_eci_coords():
 
 
 @pytest.mark.parametrize("first_source_antizenith", [True, False])
-def test_coherency_calc(first_source_antizenith):
+@pytest.mark.parametrize("use_horizon_sources", [True, False])
+def test_coherency_calc(first_source_antizenith, use_horizon_sources):
     """Test calculation of coherency matrix."""
     params, sky_model, *_ = get_standard_sim_params(
         use_analytic_beam=False,
@@ -203,6 +206,21 @@ def test_coherency_calc(first_source_antizenith):
         first_source_antizenith=first_source_antizenith,
     )
 
+    # Set up sky model for EW/NS horizon sources
+    if use_horizon_sources:
+        ra = np.array([1.064, 2.637])
+        dec = np.array([1.034, 0.0015])
+        sky_model = SkyModel(
+            name=["0", "1"],
+            ra=Longitude(ra, "rad"),
+            dec=Latitude(dec, "rad"),
+            frame="icrs",
+            spectral_type="spectral_index",
+            spectral_index=np.array([0.0, 0.0]),
+            stokes=sky_model.stokes[..., :2],  # grab stokes from above
+            reference_frequency=Quantity(np.array([1e8, 1e8]), "Hz"),
+        )
+
     for time in params["times"]:
         sky_model.update_positions(
             time=time, telescope_location=params["telescope_loc"]
@@ -211,14 +229,17 @@ def test_coherency_calc(first_source_antizenith):
 
         # Calculate coherency matrix
         rotation_matrix_matvis = coordinates.calc_coherency_rotation(
-            ra=params["ra"],
-            dec=params["dec"],
+            ra=sky_model.ra.rad,
+            dec=sky_model.dec.rad,
             alt=sky_model.alt_az[0],
             az=sky_model.alt_az[1],
             location=params["telescope_loc"],
             time=time,
         )
-        assert rotation_matrix_matvis.shape == (2, 2, NPTSRC)  # Check shape
+        if use_horizon_sources:
+            assert rotation_matrix_matvis.shape == (2, 2, 2)  # Check shape
+        else:
+            assert rotation_matrix_matvis.shape == (2, 2, NPTSRC)  # Check shape
 
         # Check that the rotation matrix matches the one calculated by pyradiosky
         np.testing.assert_allclose(rotation_matrix_matvis, rotation_matrix)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -191,32 +191,32 @@ def test_equatorial_to_eci_coords():
             ra, dec, obstime, (-30.7, 21.4, 1073.0), unit="rad", frame="icrs"
         )
 
+
 def test_coherency_calc():
     """Test calculation of coherency matrix."""
 
     params, sky_model, *_ = get_standard_sim_params(
-        use_analytic_beam=False, 
+        use_analytic_beam=False,
         polarized=True,
         nsource=NPTSRC,
         ntime=NTIMES,
     )
 
     # Generate random point sources
-    for time in params['times']:
+    for time in params["times"]:
         sky_model.update_positions(
-            time=time,
-            telescope_location=params['telescope_loc']
+            time=time, telescope_location=params["telescope_loc"]
         )
         rotation_matrix = sky_model._calc_coherency_rotation()
 
         # Calculate coherency matrix
         rotation_matrix_matvis = coordinates.calc_coherency_rotation(
-            ra=params['ra'],
-            dec=params['dec'],
+            ra=params["ra"],
+            dec=params["dec"],
             alt=sky_model.alt_az[0],
             az=sky_model.alt_az[1],
-            location=params['telescope_loc'],
-            time=time
+            location=params["telescope_loc"],
+            time=time,
         )
         assert rotation_matrix_matvis.shape == (2, 2, NPTSRC)  # Check shape
 


### PR DESCRIPTION
This PR re-implements the coherency matrix rotation methods in `pyradiosky` to support simulations with polarized sky models. It also extends the methods to allow for some slightly better vectorization.