### PR TITLE
Add corrections to coherency rotation

### DIFF
--- a/src/matvis/_test_utils.py
+++ b/src/matvis/_test_utils.py
@@ -32,6 +32,7 @@ def get_standard_sim_params(
     ntime=ntime,
     nsource=nsource,
     first_source_antizenith=False,
+    use_polarized_sky=False,
 ):
     """Create some standard random simulation parameters for use in tests."""
     hera = Telescope.from_known_telescopes("hera")
@@ -115,7 +116,7 @@ def get_standard_sim_params(
     ]
     if nsource > 1:  # Add random other sources
         ra = rng.uniform(low=0.0, high=360.0, size=nsource - 1)
-        dec = -30.72 + rng.uniform(size=nsource - 1) * 10.0
+        dec = -30.72 + rng.uniform(size=nsource - 1)
         flux = rng.uniform(size=nsource - 1) * 4
         sources.extend([ra[i], dec[i], flux[i], 0] for i in range(nsource - 1))
     sources = np.array(sources)
@@ -131,6 +132,11 @@ def get_standard_sim_params(
     # are calculated later.
     stokes = np.zeros((4, 1, ra_dec.shape[0]))
     stokes[0, 0] = sources[:, 2]
+
+    if use_polarized_sky:
+        stokes[1, 0] = sources[:, 2] * 0.2
+        stokes[2, 0] = sources[:, 2] * 0.3
+        stokes[3, 0] = sources[:, 2] * 0.4
     reference_frequency = np.full(len(ra_dec), freqs[0])
 
     # Set up sky model

--- a/src/matvis/_test_utils.py
+++ b/src/matvis/_test_utils.py
@@ -116,7 +116,7 @@ def get_standard_sim_params(
     ]
     if nsource > 1:  # Add random other sources
         ra = rng.uniform(low=0.0, high=360.0, size=nsource - 1)
-        dec = -30.72 + rng.uniform(size=nsource - 1)
+        dec = -30.72 + rng.uniform(size=nsource - 1) * 10.0
         flux = rng.uniform(size=nsource - 1) * 4
         sources.extend([ra[i], dec[i], flux[i], 0] for i in range(nsource - 1))
     sources = np.array(sources)

--- a/src/matvis/core/coords.py
+++ b/src/matvis/core/coords.py
@@ -130,8 +130,8 @@ class CoordinateRotation(ABC):
             # For polarized flux, rotate the frame coherency
             self.flux_above_horizon[:n] = self._rotate_frame_coherency(
                 coherency_matrix=flux[above_horizon],
-                ra=self.skycoords.ra.rad[above_horizon],
-                dec=self.skycoords.dec.rad[above_horizon],
+                ra=self.skycoords.ra.rad[slc][above_horizon],
+                dec=self.skycoords.dec.rad[slc][above_horizon],
                 alt=np.pi / 2 - za,
                 az=az,
                 time=self.times[t],
@@ -169,7 +169,7 @@ class CoordinateRotation(ABC):
         # size (2, 2, nsources), and coherency matrix is a matrix of size
         # (nsources, nfreq, 2, 2).
         coherency_matrix = self.xp.einsum(
-            "abn,nfbc,dcn->nfad", coherency_rotator, coherency_matrix, coherency_rotator
+            "ban,nfbc,cdn->nfad", coherency_rotator, coherency_matrix, coherency_rotator
         )
         return coherency_matrix
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -204,6 +204,7 @@ def test_coherency_calc(first_source_antizenith, use_horizon_sources):
         nsource=NPTSRC,
         ntime=NTIMES,
         first_source_antizenith=first_source_antizenith,
+        use_polarized_sky=True,
     )
 
     # Set up sky model for EW/NS horizon sources

--- a/tests/test_coordrot.py
+++ b/tests/test_coordrot.py
@@ -174,7 +174,7 @@ def test_polarized_flux(first_source_antizenith):
     params, sky_model, *_ = get_standard_sim_params(
         use_analytic_beam=False,
         polarized=True,
-        nsource=50,
+        nsource=10,
         ntime=2,
         first_source_antizenith=first_source_antizenith,
         use_polarized_sky=True,

--- a/tests/test_coordrot.py
+++ b/tests/test_coordrot.py
@@ -174,21 +174,17 @@ def test_polarized_flux(first_source_antizenith):
     params, sky_model, *_ = get_standard_sim_params(
         use_analytic_beam=False,
         polarized=True,
-        nsource=10,
+        nsource=50,
         ntime=2,
         first_source_antizenith=first_source_antizenith,
+        use_polarized_sky=True,
     )
 
-    stokes = sky_model.stokes.value
-    coherency_matrix = 0.5 * np.array(
-        [
-            [stokes[0] + stokes[1], stokes[2] + 1j * stokes[3]],
-            [stokes[2] - stokes[3], stokes[0] - stokes[1]],
-        ]
-    )
+    # calculate the frame coherency matrix
+    sky_model.calc_frame_coherency()
 
     coord_mgr = CoordinateRotationAstropy(
-        flux=coherency_matrix.T,
+        flux=sky_model.frame_coherency.T,
         times=params["times"],
         telescope_loc=params["telescope_loc"],
         skycoords=sky_model.skycoord,


### PR DESCRIPTION
This PR fixes an existing bug in the coherency rotation code, where the coherency calculation selects the ra/dec of the wrong sources when some sources exist below the horizon in the simulation. The previous tests didn't fail due to a combination of most sources being above the horizon in the tests and the fact that I accidentally only used a diagonal coherency matrix (just Stokes I) in the tests.