### PR TITLE
maint: don't import pkg_resources any more

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install Build Tools
         run: pip install build twine

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install Build Tools
         run: pip install build

--- a/.github/workflows/run_notebooks.yaml
+++ b/.github/workflows/run_notebooks.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install
         run: |

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@main
         with:

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@main
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     pyuvdata>=3.2.0
     rich
     scipy
-python_requires = >=3.10
+python_requires = >=3.11
 include_package_data = True
 package_dir =
     =src

--- a/src/matvis/__init__.py
+++ b/src/matvis/__init__.py
@@ -1,16 +1,16 @@
 """A fast visibility simulator based on per-antenna calculations."""
 
-from importlib.metadata import DistributionNotFound, version
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__
     __version__ = version(dist_name)
-except DistributionNotFound:  # pragma: no cover
+except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 finally:
-    del version, DistributionNotFound
+    del version, PackageNotFoundError
 
 try:
     import cupy

--- a/src/matvis/__init__.py
+++ b/src/matvis/__init__.py
@@ -1,17 +1,16 @@
 """A fast visibility simulator based on per-antenna calculations."""
 
-from pkg_resources import DistributionNotFound, get_distribution
-
+from importlib.metadata import DistributionNotFound, version
 from pathlib import Path
 
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__
-    __version__ = get_distribution(dist_name).version
+    __version__ = version(dist_name)
 except DistributionNotFound:  # pragma: no cover
     __version__ = "unknown"
 finally:
-    del get_distribution, DistributionNotFound
+    del version, DistributionNotFound
 
 try:
     import cupy

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
This removes the usage of `pkg_resources` which was deprecated in python 3.12