### PR TITLE
docs: separate summary line from params in gpu simulate

### DIFF
--- a/src/matvis/cpu/cpu.py
+++ b/src/matvis/cpu/cpu.py
@@ -122,10 +122,11 @@ def simulate(
         The minimum number of chunks to break the source axis into.
     source_buffer : float, optional
         The fraction of the total sources (per chunk) to pre-allocate memory for.
-        Default is 1.0, which allows for 10% variance around half the sources
-        (since half should be below the horizon). If you have a particular sky model in
-        which you expect more or less sources to appear above the horizon at any time,
-        set this to a different value.
+        Default is 1.0, which pre-allocates for all sources in each chunk. This
+        avoids assuming that only a subset of sources will be above the horizon,
+        but uses more memory. If you expect fewer or more sources to appear above
+        the horizon at any time for a particular sky model, set this to a different
+        value.
     coord_method_params
         Parameters particular to the coordinate rotation method of choice. For example,
         for the CoordinateRotationERFA (and GPU version of the same) method, there

--- a/src/matvis/cpu/cpu.py
+++ b/src/matvis/cpu/cpu.py
@@ -117,12 +117,12 @@ def simulate(
         The maximum memory (in bytes) to use for the visibility calculation. This is
         not a hard-set limit, but rather a guideline for how much memory to use. If the
         expected memory usage is more than this, the calculation will be broken up into
-        chunks. Default is 512 MB.
+        chunks.
     min_chunks : int, optional
-        The minimum number of chunks to break the source axis into. Default is 1.
+        The minimum number of chunks to break the source axis into.
     source_buffer : float, optional
         The fraction of the total sources (per chunk) to pre-allocate memory for.
-        Default is 0.55, which allows for 10% variance around half the sources
+        Default is 1.0, which allows for 10% variance around half the sources
         (since half should be below the horizon). If you have a particular sky model in
         which you expect more or less sources to appear above the horizon at any time,
         set this to a different value.

--- a/src/matvis/gpu/gpu.py
+++ b/src/matvis/gpu/gpu.py
@@ -250,4 +250,4 @@ def simulate(
     return vis if polarized else vis[:, :, 0, 0]
 
 
-simulate.__doc__ += f"\n{simcpu.__doc__}"
+simulate.__doc__ = (simulate.__doc__ or "") + f"\n{simcpu.__doc__ or ''}"

--- a/src/matvis/gpu/gpu.py
+++ b/src/matvis/gpu/gpu.py
@@ -250,4 +250,4 @@ def simulate(
     return vis if polarized else vis[:, :, 0, 0]
 
 
-simulate.__doc__ += simcpu.__doc__
+simulate.__doc__ += f"\n{simcpu.__doc__}"


### PR DESCRIPTION
A couple of extra small documentation improvements, fixes the GPU documentation which was not separating the summary line from the parameter list (ending up in awful html rendering).