### PR TITLE
ci: don't fail Testing jobs on codecov upload for Dependabot PRs

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -55,7 +55,11 @@ jobs:
         with:
           file: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }} # required
-          fail_ci_if_error: true
+          # Dependabot-triggered runs don't receive repository secrets (a GitHub
+          # security restriction), so CODECOV_TOKEN is empty and the upload is
+          # rejected. Don't fail the whole job in that case; still fail hard for
+          # every other trigger where the token is genuinely available.
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
 
   gpu_tests:
     env:
@@ -106,5 +110,7 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
+          # See comment in cpu_tests above: Dependabot runs get no repo secrets,
+          # so CODECOV_TOKEN is empty there and the upload is expected to fail.
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Dependabot PRs #140–#143 (bumping `codecov/codecov-action`, `actions/checkout`, `actions/setup-python`, `actions/setup-node`) are all failing every "Testing" matrix job uniformly, despite each only touching one unrelated line in `test_suite.yaml`.
- Root cause: GitHub does not pass repository secrets to workflow runs triggered by Dependabot PRs (a security restriction). `CODECOV_TOKEN` is therefore empty on those runs, `codecov/codecov-action@v4` falls back to a tokenless upload, and the Codecov backend rejects it with `Token required because branch is protected`. Since `fail_ci_if_error: true` was set, this turns an otherwise fully green run into a hard CI failure.
- Confirmed all 121 tests pass in every affected job (`84 passed, 41 skipped` on each hosted matrix leg, `50 passed, 4 skipped` on the self-hosted GPU job) — only the "Upload coverage report" step fails, and only on Dependabot-triggered runs. A same-day, same-repo `pre-commit-ci` PR (non-Dependabot) uploaded coverage successfully with the same workflow, confirming the token/secret is the differentiator, not the test code or `main` itself.

## Fix

Scope `fail_ci_if_error` to `github.actor != 'dependabot[bot]'` in both the `cpu_tests` and `gpu_tests` jobs, so:
- Normal pushes/PRs (which do have `CODECOV_TOKEN`) still fail CI on a genuine coverage-upload problem.
- Dependabot PRs no longer fail CI purely because the secret isn't available to them — a known GitHub platform limitation, not a bug in this repo's code.

This does not touch or attempt to merge PRs #140–#143 themselves; those still need their own review since they're all major-version Action bumps.

## Test plan

- [ ] CI green on this PR's own Testing matrix (uses the same secrets-available path as any non-Dependabot PR, so `fail_ci_if_error` stays `true` here — a genuine regression would still be caught)
- [ ] Once merged, re-run the Testing workflow on #140–#143 to confirm they go green